### PR TITLE
feat: Strengthen access control

### DIFF
--- a/app/cogs/ask_drivers.py
+++ b/app/cogs/ask_drivers.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 
 from app.core.enums import ChannelIds, FeatureFlagNames, RoleIds
+from app.utils.channel_whitelist import BOT_TESTING_CHANNELS, is_allowed_locations
 from app.utils.checks import feature_flag_enabled
 from app.utils.format_message import ping_role_with_message
 
@@ -19,12 +20,11 @@ class AskDrivers(commands.Cog):
     @feature_flag_enabled(FeatureFlagNames.BOT)
     async def ask_drivers(self, interaction: discord.Interaction, message: str) -> None:
         """Pings the driver role with a custom message."""
-        # Only allow usage in the DRIVER_CHAT_WOOOOO channel
-        if interaction.channel_id != ChannelIds.SERVING__DRIVER_CHAT_WOOOOO:
-            await interaction.response.send_message(
-                f"`/ask-drivers` can only be used in <#{ChannelIds.SERVING__DRIVER_CHAT_WOOOOO}>",
-                ephemeral=True,
-            )
+        if not await is_allowed_locations(
+            interaction,
+            interaction.channel_id,
+            BOT_TESTING_CHANNELS | {ChannelIds.SERVING__DRIVER_CHAT_WOOOOO},
+        ):
             return
 
         message_to_send = ping_role_with_message(RoleIds.DRIVER, message)

--- a/app/cogs/events.py
+++ b/app/cogs/events.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 
 from app.core.enums import FeatureFlagNames
-from app.utils.checks import feature_flag_enabled
+from app.utils.checks import feature_flag_enabled, is_admin
 
 
 class Events(commands.Cog):
@@ -19,6 +19,7 @@ class Events(commands.Cog):
         role_name="Name of the role to assign.",
     )
     @feature_flag_enabled(FeatureFlagNames.BOT)
+    @is_admin()
     async def give_role(
         self,
         interaction: discord.Interaction,

--- a/app/cogs/non_discord_rides.py
+++ b/app/cogs/non_discord_rides.py
@@ -11,6 +11,7 @@ from app.core.enums import (
     FeatureFlagNames,
 )
 from app.core.models import NonDiscordRides
+from app.utils.channel_whitelist import LOCATIONS_CHANNELS_WHITELIST, is_allowed_locations
 from app.utils.checks import feature_flag_enabled
 from app.utils.time_helpers import get_next_date_obj
 
@@ -53,6 +54,11 @@ class NonDiscordRidesCog(commands.Cog):
     async def add_pickup(
         self, interaction: discord.Interaction, name: str, day: str, location: str
     ):
+        if not await is_allowed_locations(
+            interaction, interaction.channel_id, LOCATIONS_CHANNELS_WHITELIST
+        ):
+            return
+
         try:
             async with AsyncSessionLocal() as session:
                 session.add(
@@ -78,6 +84,11 @@ class NonDiscordRidesCog(commands.Cog):
         """
         Removes a non-Discord user's pickup entry.
         """
+        if not await is_allowed_locations(
+            interaction, interaction.channel_id, LOCATIONS_CHANNELS_WHITELIST
+        ):
+            return
+
         date_to_remove = get_next_date_obj(day)
 
         async with AsyncSessionLocal() as session:
@@ -129,6 +140,11 @@ class NonDiscordRidesCog(commands.Cog):
         """
         Lists all non-Discord user pickups for a given day.
         """
+        if not await is_allowed_locations(
+            interaction, interaction.channel_id, LOCATIONS_CHANNELS_WHITELIST
+        ):
+            return
+
         date_to_list = get_next_date_obj(day)
 
         async with AsyncSessionLocal() as session:

--- a/app/utils/channel_whitelist.py
+++ b/app/utils/channel_whitelist.py
@@ -5,34 +5,34 @@ import discord
 from app.core.enums import ChannelIds
 from app.core.logger import logger
 
-LOCATIONS_CHANNELS_WHITELIST = [
-    ChannelIds.SERVING__DRIVER_BOT_SPAM,
-    ChannelIds.SERVING__LEADERSHIP,
-    ChannelIds.SERVING__DRIVER_CHAT_WOOOOO,
-]
-
-BOT_TESTING_CHANNELS = [
+BOT_TESTING_CHANNELS = {
     ChannelIds.BOT_STUFF__BOTS,
     ChannelIds.BOT_STUFF__BOT_SPAM_2,
     ChannelIds.BOT_STUFF__BOT_LOGS,
-]
+}
+LOCATIONS_CHANNELS_WHITELIST = BOT_TESTING_CHANNELS | {
+    ChannelIds.SERVING__DRIVER_BOT_SPAM,
+    ChannelIds.SERVING__LEADERSHIP,
+    ChannelIds.SERVING__DRIVER_CHAT_WOOOOO,
+}
 
 
 async def is_allowed_locations(
     interaction: discord.Interaction,
     channel_id: int,
+    whitelisted_channels: set[int] = BOT_TESTING_CHANNELS,
 ) -> bool:
-    if channel_id in BOT_TESTING_CHANNELS:
+    if channel_id in whitelisted_channels:
         return True
-    if channel_id not in LOCATIONS_CHANNELS_WHITELIST:
-        await interaction.response.send_message(
-            "Command cannot be used in this channel.",
-            ephemeral=True,
-        )
-        logger.info(
-            "Command not allowed in #%s by %s",
-            interaction.channel,
-            interaction.user,
-        )
-        return False
-    return True
+
+    await interaction.response.send_message(
+        f"`/{interaction.data['name']}` cannot be used in #{interaction.channel}.",
+        ephemeral=True,
+    )
+    logger.info(
+        "/%s not allowed in #%s by %s",
+        interaction.data["name"],
+        interaction.channel,
+        interaction.user,
+    )
+    return False


### PR DESCRIPTION
Puts restriction on where command is allowed to be run on most commands. All commands that reveal locations are restricted to `#driver-chat-wooooo`, `#driver-bot-spam`, and the bot testing channels.