### PR TITLE
feat: gate send_error_to_discord behind a feature flag

### DIFF
--- a/backend/bot/core/enums.py
+++ b/backend/bot/core/enums.py
@@ -68,6 +68,7 @@ class FeatureFlagNames(StrEnum):
     LOG_REACTIONS = "log_reactions"
     EVENT_THREADS = "event_threads"
     LATE_RIDES_REACT = "late_rides_react"
+    SEND_ERRORS_TO_DISCORD = "send_errors_to_discord"
 
 
 class JobName(StrEnum):

--- a/backend/bot/core/error_reporter.py
+++ b/backend/bot/core/error_reporter.py
@@ -6,6 +6,7 @@ import traceback
 import discord
 
 from bot.core.bot_instance import get_bot
+from bot.core.enums import FeatureFlagNames
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,13 @@ def _get_config() -> tuple[str, int | None]:
     raw = os.getenv("ERROR_CHANNEL_ID")
     channel_id = int(raw) if raw else None
     return app_env, channel_id
+
+
+def _is_send_errors_enabled() -> bool:
+    from bot.repositories.feature_flags_repository import FeatureFlagsRepository
+
+    flag_value = FeatureFlagNames.SEND_ERRORS_TO_DISCORD.value
+    return FeatureFlagsRepository._cache.get(flag_value, False)
 
 
 async def send_error_to_discord(
@@ -28,6 +36,9 @@ async def send_error_to_discord(
     """
     app_env, error_channel_id = _get_config()
     if app_env == "local" or error_channel_id is None:
+        return
+
+    if not _is_send_errors_enabled():
         return
 
     bot = get_bot()

--- a/backend/tests/unit/test_error_reporter.py
+++ b/backend/tests/unit/test_error_reporter.py
@@ -7,6 +7,8 @@ import pytest
 
 from bot.core.error_reporter import _get_config, send_error_to_discord
 
+_ENABLED = "bot.core.error_reporter._is_send_errors_enabled"
+
 
 class TestGetConfig:
     """Tests for _get_config."""
@@ -46,14 +48,22 @@ class TestSendErrorToDiscord:
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
-    @patch("bot.core.error_reporter.get_bot", return_value=None)
-    async def test_skips_when_bot_not_ready(self, mock_bot, mock_config):
+    @patch(_ENABLED, return_value=False)
+    async def test_skips_when_flag_disabled(self, mock_flag, mock_config):
         await send_error_to_discord("test error")
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
+    @patch("bot.core.error_reporter.get_bot", return_value=None)
+    async def test_skips_when_bot_not_ready(self, mock_bot, mock_flag, mock_config):
+        await send_error_to_discord("test error")
+
+    @pytest.mark.asyncio
+    @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
     @patch("bot.core.error_reporter.get_bot")
-    async def test_sends_error_message(self, mock_get_bot, mock_config):
+    async def test_sends_error_message(self, mock_get_bot, mock_flag, mock_config):
         mock_channel = AsyncMock(spec=discord.TextChannel)
         mock_bot = MagicMock()
         mock_bot.get_channel.return_value = mock_channel
@@ -67,8 +77,9 @@ class TestSendErrorToDiscord:
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
     @patch("bot.core.error_reporter.get_bot")
-    async def test_sends_error_with_traceback(self, mock_get_bot, mock_config):
+    async def test_sends_error_with_traceback(self, mock_get_bot, mock_flag, mock_config):
         mock_channel = AsyncMock(spec=discord.TextChannel)
         mock_bot = MagicMock()
         mock_bot.get_channel.return_value = mock_channel
@@ -83,8 +94,9 @@ class TestSendErrorToDiscord:
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
     @patch("bot.core.error_reporter.get_bot")
-    async def test_sends_error_with_explicit_traceback(self, mock_get_bot, mock_config):
+    async def test_sends_error_with_explicit_traceback(self, mock_get_bot, mock_flag, mock_config):
         mock_channel = AsyncMock(spec=discord.TextChannel)
         mock_bot = MagicMock()
         mock_bot.get_channel.return_value = mock_channel
@@ -95,8 +107,9 @@ class TestSendErrorToDiscord:
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
     @patch("bot.core.error_reporter.get_bot")
-    async def test_long_traceback_chunked(self, mock_get_bot, mock_config):
+    async def test_long_traceback_chunked(self, mock_get_bot, mock_flag, mock_config):
         mock_channel = AsyncMock(spec=discord.TextChannel)
         mock_bot = MagicMock()
         mock_bot.get_channel.return_value = mock_channel
@@ -109,8 +122,9 @@ class TestSendErrorToDiscord:
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
     @patch("bot.core.error_reporter.get_bot")
-    async def test_channel_not_text_channel(self, mock_get_bot, mock_config):
+    async def test_channel_not_text_channel(self, mock_get_bot, mock_flag, mock_config):
         mock_channel = MagicMock()  # Not a TextChannel
         mock_bot = MagicMock()
         mock_bot.get_channel.return_value = mock_channel
@@ -121,8 +135,9 @@ class TestSendErrorToDiscord:
 
     @pytest.mark.asyncio
     @patch("bot.core.error_reporter._get_config", return_value=("production", 123))
+    @patch(_ENABLED, return_value=True)
     @patch("bot.core.error_reporter.get_bot")
-    async def test_channel_not_found(self, mock_get_bot, mock_config):
+    async def test_channel_not_found(self, mock_get_bot, mock_flag, mock_config):
         mock_bot = MagicMock()
         mock_bot.get_channel.return_value = None
         mock_get_bot.return_value = mock_bot


### PR DESCRIPTION
Adds SEND_ERRORS_TO_DISCORD feature flag so Discord error reporting can be toggled without a redeploy. Defaults to disabled on first seed.

