### PR TITLE
fix(spa): prevent blank page from stale cached index.html after login

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -160,10 +160,12 @@ if admin_ui_path.is_dir():
         full_path = admin_ui_path / file_path
         if file_path and full_path.is_file():
             return FileResponse(full_path)
-        # Otherwise, serve the SPA index.html
+        # Otherwise, serve the SPA index.html.
+        # no-store prevents browsers from caching index.html across deploys,
+        # which would cause old hashed asset URLs to 404 and break the page.
         index_path = admin_ui_path / "index.html"
         if index_path.is_file():
-            return FileResponse(index_path)
+            return FileResponse(index_path, headers={"Cache-Control": "no-store"})
         # If no index.html, return 404
         raise HTTPException(status_code=404, detail="Not Found")
 

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -29,8 +29,15 @@ function AuthGuard() {
         )
     }
 
-    if (error instanceof ApiError && error.status === 401) {
-        return null
+    if (error) {
+        if (error instanceof ApiError && error.status === 401) {
+            return null
+        }
+        return (
+            <div className="min-h-screen flex items-center justify-center text-slate-500">
+                Something went wrong. <button className="ml-2 underline" onClick={() => window.location.reload()}>Reload</button>
+            </div>
+        )
     }
 
     return <Outlet />


### PR DESCRIPTION
Serve index.html with Cache-Control: no-store so browsers always fetch a fresh copy after deploys, preventing old hashed asset URLs from 404-ing and leaving a blank page after the OAuth redirect.

Also fix AuthGuard to show an error message for non-401 failures instead of silently falling through and rendering the page unauthenticated.

