### PR TITLE
fix(auth): invalidate sessions when revoking a user account

### DIFF
--- a/backend/bot/repositories/auth_sessions_repository.py
+++ b/backend/bot/repositories/auth_sessions_repository.py
@@ -70,6 +70,13 @@ class AuthSessionsRepository:
         await session.commit()
 
     @staticmethod
+    async def delete_by_email(session: AsyncSession, email: str) -> int:
+        """Delete all sessions for a given email. Returns the number of rows removed."""
+        result = await session.execute(delete(AuthSession).where(AuthSession.email == email))
+        await session.commit()
+        return result.rowcount
+
+    @staticmethod
     async def delete_expired(session: AsyncSession) -> int:
         """Delete all expired sessions and return the number of rows removed."""
         result = await session.execute(

--- a/backend/bot/services/user_accounts_service.py
+++ b/backend/bot/services/user_accounts_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bot.core.database import AsyncSessionLocal
 from bot.core.enums import AccountRoles
 from bot.core.models import UserAccount
+from bot.repositories.auth_sessions_repository import AuthSessionsRepository
 from bot.repositories.user_accounts_repository import UserAccountsRepository
 
 ROLE_LEVELS: dict[str, int] = {
@@ -64,9 +65,20 @@ class UserAccountsService:
 
     @staticmethod
     async def revoke(account_id: int) -> bool:
-        """Delete a user account / revoke an invite."""
+        """Delete a user account / revoke an invite, and invalidate all active sessions."""
         async with AsyncSessionLocal() as session:
-            return await UserAccountsRepository.delete_by_id(session, account_id)
+            account = await session.get(UserAccount, account_id)
+            if not account:
+                return False
+            email = account.email
+            await session.delete(account)
+            await session.commit()
+
+        if email:
+            async with AsyncSessionLocal() as session:
+                await AuthSessionsRepository.delete_by_email(session, email)
+
+        return True
 
     @staticmethod
     async def has_minimum_role(


### PR DESCRIPTION
When an account was deleted via the admin UI, active session cookies remained valid, leaving the user stuck on a 403 with no account row.

