### PR TITLE
feat(sse): live-update reaction log via Server-Sent Events

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -30,6 +30,7 @@ from api.routes.list_pickups import router as list_pickups_router
 from api.routes.locations import router as locations_router
 from api.routes.me import router as me_router
 from api.routes.reaction_log import router as reaction_log_router
+from api.routes.reaction_log_stream import router as reaction_log_stream_router
 from api.routes.route_builder import router as route_builder_router
 from api.routes.user_preferences import router as user_preferences_router
 from api.routes.usernames import router as usernames_router
@@ -127,6 +128,7 @@ app.include_router(admin_users_router)
 app.include_router(user_preferences_router)
 app.include_router(usernames_router)
 app.include_router(reaction_log_router)
+app.include_router(reaction_log_stream_router)
 
 # Mount static files for React SPA (if directory exists)
 admin_ui_path = Path("admin_ui")

--- a/backend/api/routes/reaction_log_stream.py
+++ b/backend/api/routes/reaction_log_stream.py
@@ -1,0 +1,57 @@
+"""
+Reaction Log Stream Endpoint
+
+GET /api/reaction-log/stream — SSE stream of live ride reaction events.
+"""
+
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from api.auth import require_ride_coordinator
+from bot.core import reaction_broadcaster
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_HEARTBEAT_INTERVAL = 30
+
+
+@router.get(
+    "/api/reaction-log/stream",
+    dependencies=[Depends(require_ride_coordinator)],
+)
+async def reaction_log_stream() -> StreamingResponse:
+    """
+    SSE stream of live ride reaction events.
+
+    Yields a JSON data frame for each new event and a heartbeat comment
+    every 30 seconds to keep the connection alive through proxies.
+    """
+
+    async def event_generator():
+        q = reaction_broadcaster.subscribe()
+        try:
+            while True:
+                try:
+                    event = await asyncio.wait_for(q.get(), timeout=_HEARTBEAT_INTERVAL)
+                    yield f"data: {json.dumps(event)}\n\n"
+                except TimeoutError:
+                    yield ": heartbeat\n\n"
+        except asyncio.CancelledError:
+            logger.debug("reaction_log_stream: client disconnected")
+        finally:
+            reaction_broadcaster.unsubscribe(q)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/bot/core/reaction_broadcaster.py
+++ b/backend/bot/core/reaction_broadcaster.py
@@ -1,0 +1,34 @@
+"""Module-level asyncio pub/sub for ride reaction events."""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+_subscribers: set[asyncio.Queue] = set()
+
+
+def subscribe() -> asyncio.Queue:
+    """Register a new subscriber and return its queue."""
+    q: asyncio.Queue = asyncio.Queue()
+    _subscribers.add(q)
+    logger.debug("reaction_broadcaster: subscriber added (total=%d)", len(_subscribers))
+    return q
+
+
+def unsubscribe(q: asyncio.Queue) -> None:
+    """Remove a subscriber queue."""
+    _subscribers.discard(q)
+    logger.debug("reaction_broadcaster: subscriber removed (total=%d)", len(_subscribers))
+
+
+async def publish(event: dict) -> None:
+    """Broadcast an event dict to all current subscribers."""
+    if not _subscribers:
+        return
+    logger.debug("reaction_broadcaster: publishing to %d subscribers", len(_subscribers))
+    for q in list(_subscribers):
+        try:
+            await q.put(event)
+        except Exception:
+            logger.exception("reaction_broadcaster: failed to put event on queue")

--- a/backend/bot/repositories/ride_reaction_events_repository.py
+++ b/backend/bot/repositories/ride_reaction_events_repository.py
@@ -25,8 +25,8 @@ class RideReactionEventsRepository:
         occurred_at: datetime.datetime,
         ride_date: datetime.date | None,
         ride_type: str | None,
-    ) -> None:
-        """Insert a new ride reaction event row."""
+    ) -> RideReactionEvent:
+        """Insert a new ride reaction event row and return it with its generated id."""
         try:
             entry = RideReactionEvent(
                 message_id=message_id,
@@ -40,6 +40,7 @@ class RideReactionEventsRepository:
             )
             session.add(entry)
             await session.commit()
+            return entry
         except Exception:
             await session.rollback()
             raise

--- a/backend/bot/services/ride_reaction_log_service.py
+++ b/backend/bot/services/ride_reaction_log_service.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo
 
 import discord
 
+from bot.core import reaction_broadcaster
 from bot.core.database import AsyncSessionLocal
 from bot.core.enums import ReactionAction
 from bot.repositories.ride_reaction_events_repository import RideReactionEventsRepository
@@ -63,19 +64,20 @@ class RideReactionLogService:
 
             discord_username = user.name
 
+            occurred_at = datetime.datetime.now(datetime.UTC)
             async with AsyncSessionLocal() as session:
                 display_name = await WhoisRepository.get_display_name(session, discord_username)
                 logger.debug(
                     "record_ask_rides_reaction: display_name=%s, writing to DB", display_name
                 )
-                await RideReactionEventsRepository.record_event(
+                event_row = await RideReactionEventsRepository.record_event(
                     session=session,
                     message_id=str(payload.message_id),
                     discord_username=discord_username,
                     display_name=display_name,
                     emoji=str(payload.emoji),
                     action=action.value,
-                    occurred_at=datetime.datetime.now(datetime.UTC),
+                    occurred_at=occurred_at,
                     ride_date=ride_date,
                     ride_type=ride_type,
                 )
@@ -86,6 +88,19 @@ class RideReactionLogService:
                 action,
                 ride_type,
                 ride_date,
+            )
+            await reaction_broadcaster.publish(
+                {
+                    "id": event_row.id,
+                    "message_id": event_row.message_id,
+                    "discord_username": event_row.discord_username,
+                    "display_name": event_row.display_name,
+                    "emoji": event_row.emoji,
+                    "action": event_row.action,
+                    "occurred_at": event_row.occurred_at.isoformat(),
+                    "ride_date": event_row.ride_date.isoformat() if event_row.ride_date else None,
+                    "ride_type": event_row.ride_type,
+                }
             )
         except Exception:
             logger.exception("Failed to record ask-rides reaction event")

--- a/frontend/src/pages/ReactionLog.tsx
+++ b/frontend/src/pages/ReactionLog.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
-import { apiFetch } from '../lib/api'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiFetch, getApiUrl } from '../lib/api'
 import { Button } from '../components/ui/button'
 import { PageHeader, PageLayout } from '../components/shared'
 import { ModeToggle } from '../components/mode-toggle'
@@ -240,6 +240,17 @@ function ReactionLog() {
     const availableEmojis = Array.from(
         new Set(allData?.rides.flatMap((r) => r.events.map((e) => e.emoji)) ?? [])
     ).sort()
+
+    const queryClient = useQueryClient()
+
+    useEffect(() => {
+        const es = new EventSource(getApiUrl('/api/reaction-log/stream'), { withCredentials: true })
+        es.onmessage = () => {
+            void queryClient.invalidateQueries({ queryKey: ['reaction-log'] })
+            void queryClient.invalidateQueries({ queryKey: ['reaction-log-all-emojis'] })
+        }
+        return () => es.close()
+    }, [queryClient])
 
     const setFilter = <K extends keyof Filters>(key: K, value: Filters[K]) => {
         setFilters((prev) => ({ ...prev, [key]: value }))


### PR DESCRIPTION
- Add reaction_broadcaster module (asyncio pub/sub)
- Publish event to broadcaster after each DB write in ride_reaction_log_service
- Add GET /api/reaction-log/stream SSE endpoint with 30s heartbeat
- Frontend opens EventSource on mount and invalidates query cache on message

