### PR TITLE
fix(frontend): replace hardcoded color utilities with semantic tokens

### DIFF
--- a/frontend/src/components/AskRidesDashboard/AskRidesDashboard.tsx
+++ b/frontend/src/components/AskRidesDashboard/AskRidesDashboard.tsx
@@ -114,7 +114,7 @@ function AskRidesDashboard({ canManage }: AskRidesDashboardProps) {
                             <span><span className="font-medium">Disabled:</span> The feature flag for this job is turned off.</span>
                         </li>
                     </ul>
-                    <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
+                    <p className="mt-3 text-sm text-muted-foreground">
                         Use the <span className="font-medium">⏸️ Pause</span> / <span className="font-medium">▶️ Resume</span> buttons on each card to temporarily skip a job. Use the <span className="font-medium">📨 Send now</span> button to manually trigger all ask rides messages if the scheduled send was missed (e.g. due to a service crash).
                     </p>
                 </InfoPanel>

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -23,7 +23,7 @@ function AuthGuard() {
 
     if (isLoading) {
         return (
-            <div className="min-h-screen flex items-center justify-center text-slate-500">
+            <div className="min-h-screen flex items-center justify-center text-muted-foreground">
                 Loading…
             </div>
         )
@@ -34,7 +34,7 @@ function AuthGuard() {
             return null
         }
         return (
-            <div className="min-h-screen flex items-center justify-center text-slate-500">
+            <div className="min-h-screen flex items-center justify-center text-muted-foreground">
                 Something went wrong. <button className="ml-2 underline" onClick={() => window.location.reload()}>Reload</button>
             </div>
         )

--- a/frontend/src/components/DriverReactions.tsx
+++ b/frontend/src/components/DriverReactions.tsx
@@ -85,7 +85,7 @@ function DriverReactions() {
                     <p className="mb-2">
                         This widget tracks emoji reactions from drivers in the driver chat channel.
                     </p>
-                    <ul className="list-disc list-inside space-y-1 text-sm text-slate-600 dark:text-slate-400">
+                    <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
                         <li>Automatically switches between <strong>Friday</strong> and <strong>Sunday</strong> based on the current time.</li>
                         <li>Use the day toggle buttons to manually switch between Friday and Sunday views.</li>
                         <li>Click the refresh button to return to automatic mode and update data.</li>
@@ -122,38 +122,38 @@ function DriverReactions() {
                 {!loading && !error && data && (
                     <>
                         {!data.message_found ? (
-                            <div className="text-center py-4 text-slate-500 italic">
+                            <div className="text-center py-4 text-muted-foreground italic">
                                 No driver message found for {capitalize(activeDay)}.
                             </div>
                         ) : (
                             <div className="space-y-4">
                                 {Object.keys(data.reactions).length === 0 ? (
-                                    <div className="text-center py-4 text-slate-500">No reactions found yet.</div>
+                                    <div className="text-center py-4 text-muted-foreground">No reactions found yet.</div>
                                 ) : (
-                                    <details className="group border border-slate-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-900 overflow-hidden">
-                                        <summary className="flex items-center justify-between p-4 cursor-pointer hover:bg-slate-50 dark:hover:bg-zinc-800/50 transition-colors select-none list-none [&::-webkit-details-marker]:hidden">
+                                    <details className="group border border-border rounded-lg bg-card overflow-hidden">
+                                        <summary className="flex items-center justify-between p-4 cursor-pointer hover:bg-muted/50 transition-colors select-none list-none [&::-webkit-details-marker]:hidden">
                                             <span className="sr-only">Show driver reaction details</span>
                                             <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
                                                 {Object.entries(data.reactions).map(([emoji, usernames]) => (
                                                     <div key={emoji} className="flex items-center gap-2">
                                                         <span className="text-xl">{emoji}</span>
-                                                        <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                                        <span className="text-sm font-medium text-foreground">
                                                             {usernames.length}
                                                         </span>
                                                     </div>
                                                 ))}
                                             </div>
-                                            <span className="text-slate-400 group-open:rotate-180 transition-transform duration-200 ml-4">
+                                            <span className="text-muted-foreground group-open:rotate-180 transition-transform duration-200 ml-4">
                                                 ▼
                                             </span>
                                         </summary>
-                                        <div className="px-4 pb-4 pt-0 border-t border-slate-100 dark:border-zinc-800/50">
+                                        <div className="px-4 pb-4 pt-0 border-t border-border">
                                             <div className="space-y-4 mt-4">
                                                 {Object.entries(data.reactions).map(([emoji, usernames]) => (
                                                     <div key={emoji}>
                                                         <div className="flex items-center gap-2 mb-2">
                                                             <span className="text-lg">{emoji}</span>
-                                                            <span className="text-sm font-medium text-slate-500 uppercase tracking-widest text-xs">
+                                                            <span className="text-sm font-medium text-muted-foreground uppercase tracking-widest text-xs">
                                                                 {usernames.length} {usernames.length === 1 ? 'Driver' : 'Drivers'}
                                                             </span>
                                                         </div>

--- a/frontend/src/components/EditableOutput.tsx
+++ b/frontend/src/components/EditableOutput.tsx
@@ -262,7 +262,7 @@ function EditableOutput({
     return (
         <div
             ref={containerRef}
-            className="group relative bg-slate-50 dark:bg-zinc-800/50 rounded-lg border border-slate-200 dark:border-zinc-700 p-1 transition-all hover:shadow-md hover:border-slate-300 dark:hover:border-zinc-600"
+            className="group relative bg-muted/50 rounded-lg border border-border p-1 transition-all hover:shadow-md hover:border-border/70"
         >
             <div className="absolute top-2 right-2 z-10 flex gap-2 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
                 {isModified && (
@@ -270,7 +270,7 @@ function EditableOutput({
                         onClick={onRevert}
                         variant="outline"
                         size="sm"
-                        className="h-8 px-2 text-xs border-amber-200 text-amber-700 hover:bg-amber-50 hover:text-amber-800 bg-white dark:bg-zinc-900 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
+                        className="h-8 px-2 text-xs border-amber-200 text-amber-700 hover:bg-amber-50 hover:text-amber-800 bg-card dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
                     >
                         ↩ Revert
                     </Button>
@@ -279,10 +279,10 @@ function EditableOutput({
                     onClick={() => { onCopy(); setCopied(true); setTimeout(() => setCopied(false), 2000) }}
                     size="sm"
                     variant={copied ? 'default' : 'outline'}
-                    className={`h-8 px-2 text-xs bg-white hover:bg-slate-100 dark:bg-zinc-900 ${
+                    className={`h-8 px-2 text-xs bg-card hover:bg-muted ${
                         copied
                             ? 'bg-emerald-600 hover:bg-emerald-700 text-white border-transparent dark:bg-emerald-600 dark:hover:bg-emerald-700'
-                            : 'text-slate-700 dark:text-slate-300'
+                            : 'text-foreground'
                     }`}
                 >
                     {copied ? 'Copied!' : 'Copy'}
@@ -295,7 +295,7 @@ function EditableOutput({
                 <div
                     ref={highlightRef}
                     aria-hidden
-                    className={`absolute inset-0 ${minHeight} p-4 text-sm font-mono text-slate-800 dark:text-slate-200 whitespace-pre-wrap break-words overflow-hidden pointer-events-none rounded-md`}
+                    className={`absolute inset-0 ${minHeight} p-4 text-sm font-mono text-foreground whitespace-pre-wrap break-words overflow-hidden pointer-events-none rounded-md`}
                 >
                     {highlightedContent}
                     {/* Extra line so height matches when content ends with \n */}
@@ -320,10 +320,10 @@ function EditableOutput({
             {showDropdown && dropdownPos && (
                 <ul
                     style={{ top: dropdownPos.top, left: dropdownPos.left }}
-                    className="absolute z-20 w-56 max-h-[9.5rem] overflow-y-auto rounded-md border border-slate-200 dark:border-zinc-600 bg-white dark:bg-zinc-900 shadow-lg py-1 text-sm"
+                    className="absolute z-20 w-56 max-h-[9.5rem] overflow-y-auto rounded-md border border-border bg-popover shadow-lg py-1 text-sm"
                 >
                     {suggestions.length === 0 ? (
-                        <li className="px-3 py-1.5 text-slate-400 dark:text-slate-500 select-none">
+                        <li className="px-3 py-1.5 text-muted-foreground select-none">
                             No results
                         </li>
                     ) : (
@@ -337,7 +337,7 @@ function EditableOutput({
                                 className={`px-3 py-1.5 cursor-pointer select-none ${
                                     i === activeIndex
                                         ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
-                                        : 'text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-zinc-800'
+                                        : 'text-foreground hover:bg-muted'
                                 }`}
                             >
                                 @{entry.username}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -27,16 +27,16 @@ export default class ErrorBoundary extends Component<Props, State> {
         if (this.state.hasError) {
             return (
                 <div className="min-h-screen flex items-center justify-center p-8">
-                    <div className="max-w-md w-full p-6 rounded-lg border border-red-200 bg-red-50 dark:bg-red-900/10 dark:border-red-900/50">
-                        <h2 className="text-lg font-semibold text-red-700 dark:text-red-400 mb-2">
+                    <div className="max-w-md w-full p-6 rounded-lg border border-destructive/30 bg-destructive/10">
+                        <h2 className="text-lg font-semibold text-destructive-text mb-2">
                             Something went wrong
                         </h2>
-                        <p className="text-sm text-red-600 dark:text-red-300 mb-4">
+                        <p className="text-sm text-destructive-text mb-4">
                             {this.state.error?.message || 'An unexpected error occurred.'}
                         </p>
                         <button
                             onClick={() => window.location.reload()}
-                            className="px-4 py-2 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700 transition-colors"
+                            className="px-4 py-2 text-sm font-medium rounded-md bg-destructive text-white hover:bg-destructive/90 transition-colors"
                         >
                             Reload page
                         </button>

--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -7,7 +7,7 @@ export default function ErrorMessage({ message }: ErrorMessageProps) {
     if (!message) return null
 
     return (
-        <div className="mb-4 p-4 text-red-700 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2 dark:bg-red-900/10 dark:text-red-400 dark:border-red-900/50">
+        <div className="mb-4 p-4 text-destructive-text bg-destructive/10 border border-destructive/30 rounded-lg flex items-start gap-2">
             <span className="text-lg">⚠️</span>
             <div>
                 <strong className="block mb-1 font-semibold">Error</strong>

--- a/frontend/src/components/FeatureFlagsManager.tsx
+++ b/frontend/src/components/FeatureFlagsManager.tsx
@@ -112,21 +112,21 @@ function FeatureFlagsManager() {
                 )}
 
                 {!flagsLoading && !flagsError && featureFlags.length > 0 && (
-                    <div className="rounded-lg border border-slate-200 dark:border-zinc-800 overflow-x-auto w-full max-w-[calc(100vw-3rem)]">
+                    <div className="rounded-lg border border-border overflow-x-auto w-full max-w-[calc(100vw-3rem)]">
                         <table className="w-full text-left text-sm">
-                            <thead className="bg-slate-50 dark:bg-zinc-800/50 text-slate-900 dark:text-slate-100 font-semibold border-b border-slate-200 dark:border-zinc-800">
+                            <thead className="bg-muted text-foreground font-semibold border-b border-border">
                                 <tr>
                                     <th scope="col" className="px-3 sm:px-6 py-3 sm:py-4">Feature Flag</th>
                                     <th scope="col" className="px-3 sm:px-6 py-3 sm:py-4 text-center w-[100px] sm:w-[120px]">Status</th>
                                 </tr>
                             </thead>
-                            <tbody className="divide-y divide-slate-100 dark:divide-zinc-800">
+                            <tbody className="divide-y divide-border">
                                 {featureFlags.map((flag) => (
                                     <tr
                                         key={flag.id}
-                                        className="hover:bg-slate-50 dark:hover:bg-zinc-800/30 transition-colors"
+                                        className="hover:bg-muted/50 transition-colors"
                                     >
-                                        <td className="px-3 sm:px-6 py-3 sm:py-4 font-mono text-slate-700 dark:text-slate-300 break-all">
+                                        <td className="px-3 sm:px-6 py-3 sm:py-4 font-mono text-foreground break-all">
                                             {flag.feature}
                                         </td>
                                         <td className="px-3 sm:px-6 py-3 sm:py-4 text-center">
@@ -145,7 +145,7 @@ function FeatureFlagsManager() {
                 )}
 
                 {!flagsLoading && !flagsError && featureFlags.length === 0 && (
-                    <p className="text-slate-500 italic p-4 text-center bg-slate-50 dark:bg-zinc-800/50 rounded-lg">
+                    <p className="text-muted-foreground italic p-4 text-center bg-muted/50 rounded-lg">
                         No feature flags found.
                     </p>
                 )}

--- a/frontend/src/components/InfoHelp.tsx
+++ b/frontend/src/components/InfoHelp.tsx
@@ -15,8 +15,8 @@ export function InfoToggleButton({ isOpen, onClick, title = "How to use" }: Info
             size="icon"
             onClick={onClick}
             className={`h-8 w-8 transition-colors ${isOpen
-                ? 'text-blue-600 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-300'
-                : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100'
+                ? 'text-info-text bg-info/10'
+                : 'text-muted-foreground hover:text-foreground'
                 }`}
             title={title}
         >
@@ -37,20 +37,20 @@ export function InfoPanel({ isOpen, onClose, title, children }: InfoPanelProps) 
     if (!isOpen) return null
 
     return (
-        <div className="mb-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg relative animate-in fade-in slide-in-from-top-2 duration-200">
+        <div className="mb-6 p-4 bg-info/10 border border-info/30 rounded-lg relative animate-in fade-in slide-in-from-top-2 duration-200">
             <button
                 onClick={onClose}
-                className="absolute top-2 right-2 text-blue-400 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+                className="absolute top-2 right-2 text-info/70 hover:text-info transition-colors"
                 title="Close info"
             >
                 <X className="h-4 w-4" />
                 <span className="sr-only">Close info</span>
             </button>
-            <h4 className="font-semibold text-blue-900 dark:text-blue-300 mb-2 text-sm flex items-center gap-2">
+            <h4 className="font-semibold text-info-text mb-2 text-sm flex items-center gap-2">
                 <Info className="h-4 w-4" />
                 {title}
             </h4>
-            <div className="text-sm text-blue-800 dark:text-blue-200 ml-1">
+            <div className="text-sm text-info-text ml-1">
                 {children}
             </div>
         </div>

--- a/frontend/src/components/MapLinks.tsx
+++ b/frontend/src/components/MapLinks.tsx
@@ -70,7 +70,7 @@ function MapLinks() {
 
     return (
         <SectionCard icon="📍" title="Pickup Directions" headerClassName="pb-2">
-                <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+                <p className="text-sm text-muted-foreground mb-4">
                     Select a pickup location to view it on the map and copy the
                     Google Maps link.
                 </p>
@@ -112,7 +112,7 @@ function MapLinks() {
                 </div>
 
                 {/* Map */}
-                <div className="mt-4 rounded-lg overflow-hidden border border-slate-200 dark:border-zinc-700 relative z-0">
+                <div className="mt-4 rounded-lg overflow-hidden border border-border relative z-0">
                     <MapContainer
                         center={mapCenter}
                         zoom={selectedCoords ? 16 : 14}
@@ -156,8 +156,8 @@ function MapLinks() {
 
                 {/* Action Buttons */}
                 {selectedMapUrl && (
-                    <div className="mt-4 p-4 bg-slate-50 dark:bg-zinc-800/50 rounded-lg border border-slate-100 dark:border-zinc-700 animate-in fade-in slide-in-from-bottom-2 duration-300">
-                        <div className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+                    <div className="mt-4 p-4 bg-muted/50 rounded-lg border border-border animate-in fade-in slide-in-from-bottom-2 duration-300">
+                        <div className="text-sm font-medium text-foreground mb-3">
                             {selectedLocationName}
                         </div>
                         <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/RideCoverageCheck.tsx
+++ b/frontend/src/components/RideCoverageCheck.tsx
@@ -47,7 +47,7 @@ function RideDay({ rideType, title, emoji }: RideDayProps) {
 
     if (!coverage || !coverage.message_found) {
         return (
-            <div className="p-4 text-center text-slate-500">
+            <div className="p-4 text-center text-muted-foreground">
                 No {title.toLowerCase()} message found yet
             </div>
         )
@@ -58,30 +58,30 @@ function RideDay({ rideType, title, emoji }: RideDayProps) {
         : 0
 
     return (
-        <div className="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+        <div className="border border-border rounded-lg overflow-hidden">
             <button
                 onClick={() => setIsExpanded(!isExpanded)}
-                className="w-full px-4 py-3 flex items-center justify-between bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                className="w-full px-4 py-3 flex items-center justify-between bg-muted hover:bg-muted/70 transition-colors"
             >
                 <div className="flex items-center gap-3">
                     <span className="text-2xl">{emoji}</span>
                     <div className="text-left">
-                        <h3 className="font-semibold text-slate-900 dark:text-white">{title}</h3>
-                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                        <h3 className="font-semibold text-foreground">{title}</h3>
+                        <p className="text-sm text-muted-foreground">
                             {coverage.assigned} / {coverage.total} assigned ({percentAssigned}%)
                         </p>
                     </div>
                 </div>
                 <div className="flex items-center gap-2">
                     {coverage.assigned === coverage.total ? (
-                        <span className="text-green-600 dark:text-green-400 font-medium">✓ Complete</span>
+                        <span className="text-success-text font-medium">✓ Complete</span>
                     ) : (
                         <span className="text-yellow-600 dark:text-yellow-400 font-medium">
                             {coverage.total - coverage.assigned} missing
                         </span>
                     )}
                     <svg
-                        className={`w-5 h-5 text-slate-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                        className={`w-5 h-5 text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -92,23 +92,23 @@ function RideDay({ rideType, title, emoji }: RideDayProps) {
             </button>
 
             {isExpanded && (
-                <div className="p-4 bg-white dark:bg-slate-900">
+                <div className="p-4 bg-card">
                     {coverage.users.length === 0 ? (
-                        <p className="text-center text-slate-500">No users reacted to this message</p>
+                        <p className="text-center text-muted-foreground">No users reacted to this message</p>
                     ) : (
                         <div className="space-y-2">
                             {coverage.users.map((user: RideCoverageUser) => (
                                 <div
                                     key={user.discord_username}
-                                    className="flex items-center justify-between px-3 py-2 rounded-md bg-slate-50 dark:bg-slate-800"
+                                    className="flex items-center justify-between px-3 py-2 rounded-md bg-muted"
                                 >
-                                    <span className="font-mono text-sm text-slate-900 dark:text-slate-100">
+                                    <span className="font-mono text-sm text-foreground">
                                         {user.discord_username}
                                     </span>
                                     {user.has_ride ? (
-                                        <span className="text-green-600 dark:text-green-400 font-bold text-lg">✓</span>
+                                        <span className="text-success-text font-bold text-lg">✓</span>
                                     ) : (
-                                        <span className="text-red-600 dark:text-red-400 font-bold text-lg">✗</span>
+                                        <span className="text-destructive-text font-bold text-lg">✗</span>
                                     )}
                                 </div>
                             ))}
@@ -196,11 +196,11 @@ function RideCoverageCheck() {
                                     className="fixed inset-0 z-10"
                                     onClick={() => setShowMenu(false)}
                                 />
-                                <div className="absolute right-0 top-full mt-1 z-20 bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-md shadow-xl py-1 w-48">
+                                <div className="absolute right-0 top-full mt-1 z-20 bg-popover border border-border rounded-md shadow-xl py-1 w-48">
                                     <button
                                         onClick={() => syncMutation.mutate()}
                                         disabled={syncMutation.isPending}
-                                        className="w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-slate-700 dark:text-slate-300"
+                                        className="w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-foreground"
                                     >
                                         {syncMutation.isPending ? (
                                             <>
@@ -227,7 +227,7 @@ function RideCoverageCheck() {
             }
         >
                 {syncMutation.isSuccess && (
-                    <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 rounded-md text-sm flex items-center gap-2">
+                    <div className="mb-4 p-3 bg-success/10 text-success-text rounded-md text-sm flex items-center gap-2">
                         <Check className="h-4 w-4" />
                         <span>
                             Sync completed: {syncMutation.data?.entries_added || 0} added, {syncMutation.data?.entries_removed || 0} removed
@@ -235,7 +235,7 @@ function RideCoverageCheck() {
                     </div>
                 )}
                 {syncMutation.isError && (
-                    <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 rounded-md text-sm">
+                    <div className="mb-4 p-3 bg-destructive/10 text-destructive-text rounded-md text-sm">
                         ✗ Sync failed. Please try again.
                     </div>
                 )}
@@ -250,25 +250,25 @@ function RideCoverageCheck() {
                     </p>
                     <ul className="space-y-1 mb-3">
                         <li className="flex items-center gap-2">
-                            <span className="text-green-600 dark:text-green-400 font-bold">✓</span>
+                            <span className="text-success-text font-bold">✓</span>
                             <span>User is covered (assigned to a driver)</span>
                         </li>
                         <li className="flex items-center gap-2">
-                            <span className="text-red-600 dark:text-red-400 font-bold">✗</span>
+                            <span className="text-destructive-text font-bold">✗</span>
                             <span>User not covered (needs a ride!)</span>
                         </li>
                     </ul>
 
                     <div className="space-y-3">
-                        <div className="border-t border-slate-100 dark:border-slate-800 pt-2">
-                            <p className="text-sm text-slate-600 dark:text-slate-400">
+                        <div className="border-t border-border pt-2">
+                            <p className="text-sm text-muted-foreground">
                                 This widget only appears once the first ride grouping message is posted in Discord.
                             </p>
                         </div>
 
-                        <div className="border-t border-slate-100 dark:border-slate-800 pt-2">
-                            <p className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">Tools</p>
-                            <ul className="text-sm text-slate-600 dark:text-slate-400 space-y-1">
+                        <div className="border-t border-border pt-2">
+                            <p className="text-sm font-medium text-foreground mb-1">Tools</p>
+                            <ul className="text-sm text-muted-foreground space-y-1">
                                 <li className="flex items-center gap-2">
                                     <RefreshCw className="h-3 w-3" />
                                     <span><strong>Refresh:</strong> Reloads data from database</span>

--- a/frontend/src/components/RouteBuilder/DriverSelector.tsx
+++ b/frontend/src/components/RouteBuilder/DriverSelector.tsx
@@ -38,7 +38,7 @@ export function DriverSelector({
 
     return (
         <div>
-            <div className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+            <div className="text-sm font-medium text-foreground mb-2">
                 {label}
             </div>
             <Select

--- a/frontend/src/components/RouteBuilder/LocationCombobox.tsx
+++ b/frontend/src/components/RouteBuilder/LocationCombobox.tsx
@@ -69,7 +69,7 @@ export function LocationCombobox({
                         className={
                             selectedCount === 0
                                 ? 'text-muted-foreground'
-                                : 'text-slate-900 dark:text-slate-100'
+                                : 'text-foreground'
                         }
                     >
                         {triggerLabel}
@@ -81,16 +81,16 @@ export function LocationCombobox({
                 <Popover.Content
                     align="start"
                     sideOffset={4}
-                    className="z-[1100] w-[var(--radix-popover-trigger-width)] min-w-[16rem] rounded-md border border-slate-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg outline-none"
+                    className="z-[1100] w-[var(--radix-popover-trigger-width)] min-w-[16rem] rounded-md border border-border bg-popover shadow-lg outline-none"
                 >
-                    <div className="flex items-center gap-2 border-b border-slate-200 dark:border-zinc-700 px-3 py-2">
-                        <Search className="h-4 w-4 text-slate-400 shrink-0" />
+                    <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+                        <Search className="h-4 w-4 text-muted-foreground shrink-0" />
                         <input
                             ref={inputRef}
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
                             placeholder="Search locations…"
-                            className="flex-1 bg-transparent text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-400 outline-none"
+                            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
                         />
                     </div>
                     <div
@@ -99,7 +99,7 @@ export function LocationCombobox({
                         className="max-h-64 overflow-y-auto py-1"
                     >
                         {filtered.length === 0 ? (
-                            <div className="px-3 py-6 text-center text-xs text-slate-500 dark:text-slate-400">
+                            <div className="px-3 py-6 text-center text-xs text-muted-foreground">
                                 {locations && locations.locations.length === 0
                                     ? 'No locations available'
                                     : 'No matches'}
@@ -116,14 +116,14 @@ export function LocationCombobox({
                                         onClick={() => onToggle(loc.key)}
                                         className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${isSelected
                                             ? 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300'
-                                            : 'text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-zinc-800'
+                                            : 'text-foreground hover:bg-muted'
                                             }`}
                                     >
                                         <span className="flex h-4 w-4 shrink-0 items-center justify-center">
                                             {isSelected ? (
                                                 <Check className="h-4 w-4" />
                                             ) : (
-                                                <Plus className="h-3.5 w-3.5 text-slate-400" />
+                                                <Plus className="h-3.5 w-3.5 text-muted-foreground" />
                                             )}
                                         </span>
                                         <span className="flex-1 truncate">{loc.value}</span>

--- a/frontend/src/components/RouteBuilder/RouteBuilder.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilder.tsx
@@ -504,7 +504,7 @@ function RouteBuilder() {
     const fullscreenOverlay = isFullscreenMounted
         ? createPortal(
             <div
-                className={`fixed inset-0 z-50 bg-white dark:bg-zinc-950 overflow-hidden transition-all duration-300 ease-out ${isFullscreenVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-[0.97]'
+                className={`fixed inset-0 z-50 bg-background overflow-hidden transition-all duration-300 ease-out ${isFullscreenVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-[0.97]'
                     }`}
                 onTransitionEnd={(e) => {
                     if (e.propertyName === 'opacity' && !isFullscreenVisible) {
@@ -527,14 +527,14 @@ function RouteBuilder() {
                 {/* Back button (top-left, near zoom controls) */}
                 <button
                     onClick={closeFullscreen}
-                    className="absolute top-24 left-4 z-[1000] flex items-center gap-2 px-3 py-2 bg-white/95 dark:bg-zinc-900/95 backdrop-blur-sm border border-slate-200 dark:border-zinc-700 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.1)] hover:bg-slate-50 dark:hover:bg-zinc-800 transition-colors text-slate-700 dark:text-slate-300"
+                    className="absolute top-24 left-4 z-[1000] flex items-center gap-2 px-3 py-2 bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.1)] hover:bg-muted transition-colors text-foreground"
                     title="Exit fullscreen (Esc)"
                     aria-label="Exit fullscreen map view"
                 >
                     <ArrowLeft className="h-4 w-4" />
                     <span className="text-sm font-semibold">Back</span>
                     {!isMobile && (
-                        <span className="text-[10px] font-bold tracking-wider text-slate-400 dark:text-zinc-500 bg-slate-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded ml-1">
+                        <span className="text-[10px] font-bold tracking-wider text-muted-foreground bg-muted px-1.5 py-0.5 rounded ml-1">
                             ESC
                         </span>
                     )}

--- a/frontend/src/components/RouteBuilder/RouteBuilderDesktopPanel.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilderDesktopPanel.tsx
@@ -33,12 +33,12 @@ export function RouteBuilderDesktopPanel({
             {/* Toggle button that hangs off the left edge of the panel */}
             <button
                 onClick={onTogglePanelExpanded}
-                className={`absolute -left-3.5 top-1/2 -translate-y-1/2 w-7 h-10 flex items-center justify-center bg-white dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg shadow-md hover:bg-slate-50 dark:hover:bg-zinc-700 transition-colors z-[1001]
-                     ${isPanelExpanded ? '' : 'shadow-lg bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800'}`}
+                className={`absolute -left-3.5 top-1/2 -translate-y-1/2 w-7 h-10 flex items-center justify-center bg-card border border-border rounded-lg shadow-md hover:bg-muted transition-colors z-[1001]
+                     ${isPanelExpanded ? '' : 'shadow-lg bg-success/10 border-success/30'}`}
                 title={isPanelExpanded ? 'Collapse panel' : 'Expand panel'}
             >
                 {isPanelExpanded ? (
-                    <ChevronRight className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
                 ) : (
                     <ChevronLeft className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
                 )}
@@ -46,7 +46,7 @@ export function RouteBuilderDesktopPanel({
 
             {/* Panel body */}
             <div
-                className={`w-full max-h-[calc(100vh-2rem)] overflow-hidden rounded-xl border border-slate-200 dark:border-zinc-700 bg-white/95 dark:bg-zinc-900/95 backdrop-blur-md shadow-xl transition-opacity duration-300 ${
+                className={`w-full max-h-[calc(100vh-2rem)] overflow-hidden rounded-xl border border-border bg-card/95 backdrop-blur-md shadow-xl transition-opacity duration-300 ${
                     isPanelExpanded
                         ? 'opacity-100 pointer-events-auto'
                         : 'opacity-0 pointer-events-none'
@@ -61,7 +61,7 @@ export function RouteBuilderDesktopPanel({
                             onChange={(e) => onToggleShowLabels(e.target.checked)}
                             className="w-4 h-4 rounded accent-emerald-600"
                         />
-                        <span className="text-xs font-medium text-slate-600 dark:text-slate-400">
+                        <span className="text-xs font-medium text-muted-foreground">
                             Show labels
                         </span>
                     </label>

--- a/frontend/src/components/RouteBuilder/RouteBuilderMobileSheet.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilderMobileSheet.tsx
@@ -31,16 +31,16 @@ export function RouteBuilderMobileSheet({
             }`}
             style={{ willChange: 'max-height' }}
         >
-            <div className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-md border-t border-slate-200 dark:border-zinc-700 rounded-t-2xl shadow-[0_-4px_20px_rgba(0,0,0,0.12)] overflow-hidden h-full flex flex-col">
+            <div className="bg-card/95 backdrop-blur-md border-t border-border rounded-t-2xl shadow-[0_-4px_20px_rgba(0,0,0,0.12)] overflow-hidden h-full flex flex-col">
                 {/* Header bar — entire row is the expand/collapse tap target */}
                 <button
                     onClick={() => onSetSheetExpanded(!isSheetExpanded)}
                     aria-label={isSheetExpanded ? 'Collapse panel' : 'Expand panel'}
-                    className="flex items-center w-full min-h-[3rem] px-4 bg-slate-50/80 dark:bg-zinc-800/50 active:bg-slate-100 dark:active:bg-zinc-700/60 transition-colors text-left"
+                    className="flex items-center w-full min-h-[3rem] px-4 bg-muted/80 active:bg-muted transition-colors text-left"
                 >
                     {/* Location summary */}
                     <MapPin className="h-4 w-4 text-emerald-500 shrink-0 mr-2" />
-                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex-1 truncate">
+                    <span className="text-sm font-semibold text-foreground flex-1 truncate">
                         {selectedLocationKeys.length === 0
                             ? 'Tap pins to add stops'
                             : `${selectedLocationKeys.length} location${selectedLocationKeys.length !== 1 ? 's' : ''} selected`}
@@ -56,7 +56,7 @@ export function RouteBuilderMobileSheet({
                                 onChange={(e) => onToggleShowLabels(e.target.checked)}
                                 className="w-4 h-4 rounded accent-emerald-600"
                             />
-                            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                            <span className="text-xs font-medium text-muted-foreground">
                                 Labels
                             </span>
                         </label>
@@ -65,7 +65,7 @@ export function RouteBuilderMobileSheet({
                         {selectedLocationKeys.length > 0 && (
                             <button
                                 onClick={() => panelProps.onClearAll()}
-                                className="flex items-center gap-1.5 text-xs font-medium text-red-500 dark:text-red-400 active:opacity-60 transition-opacity px-3 min-h-[44px] rounded-xl bg-red-50 dark:bg-red-900/20"
+                                className="flex items-center gap-1.5 text-xs font-medium text-destructive-text active:opacity-60 transition-opacity px-3 min-h-[44px] rounded-xl bg-destructive/10"
                             >
                                 <X className="h-3.5 w-3.5" />
                                 Clear

--- a/frontend/src/components/RouteBuilder/RouteBuilderPanelContents.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilderPanelContents.tsx
@@ -85,10 +85,10 @@ export function RouteBuilderPanelContents({
                 <div className="w-12 h-12 rounded-full bg-emerald-50 dark:bg-emerald-900/30 flex items-center justify-center mb-3">
                     <MousePointerClick className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
                 </div>
-                <div className="text-sm font-semibold text-slate-900 dark:text-white mb-1">
+                <div className="text-sm font-semibold text-foreground mb-1">
                     Tap pins to build your route
                 </div>
-                <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">
+                <p className="text-xs text-muted-foreground leading-relaxed">
                     Tap on map markers to add stops. Selected pins turn{' '}
                     <span className="text-emerald-600 dark:text-emerald-400 font-medium">green</span>{' '}
                     and are numbered in order.
@@ -101,7 +101,7 @@ export function RouteBuilderPanelContents({
         <>
             {/* Route order header + clear */}
             <div className="flex items-center justify-between mb-3">
-                <div className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+                <div className="text-sm font-semibold text-foreground">
                     Route Order ({selectedLocationKeys.length} location
                     {selectedLocationKeys.length !== 1 ? 's' : ''})
                 </div>
@@ -110,7 +110,7 @@ export function RouteBuilderPanelContents({
                     variant="ghost"
                     size="sm"
                     onClick={onClearAll}
-                    className="h-6 px-2 text-xs text-slate-500 hover:text-red-600 dark:text-slate-400 dark:hover:text-red-400"
+                    className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
                 >
                     Clear All
                 </Button>
@@ -132,8 +132,8 @@ export function RouteBuilderPanelContents({
             />
 
             {/* Arrival Time */}
-            <div className="mt-4 pt-4 border-t border-slate-200 dark:border-zinc-700">
-                <div className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+            <div className="mt-4 pt-4 border-t border-border">
+                <div className="text-sm font-medium text-foreground mb-2">
                     Arrival Time
                 </div>
                 <ArrivalTimeSelector
@@ -147,7 +147,7 @@ export function RouteBuilderPanelContents({
 
             {/* Loading indicator */}
             {routeLoading && (
-                <div className="mt-3 flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
                     <div className="h-4 w-4 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
                     Generating route…
                 </div>
@@ -155,12 +155,12 @@ export function RouteBuilderPanelContents({
 
             {/* Error */}
             {routeError && (
-                <div className="mt-2 text-xs text-red-600 dark:text-red-400">{routeError}</div>
+                <div className="mt-2 text-xs text-destructive-text">{routeError}</div>
             )}
 
             {/* Driver selector */}
             {drivers.length > 0 && (
-                <div className="mt-3 pt-3 border-t border-slate-200 dark:border-zinc-700">
+                <div className="mt-3 pt-3 border-t border-border">
                     <DriverSelector
                         drivers={drivers}
                         driverUsernameToName={driverUsernameToName}
@@ -178,7 +178,7 @@ export function RouteBuilderPanelContents({
                 const displayOriginal = prefix + originalRouteOutput
                 return (
                     <div className="mt-3">
-                        <div className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                        <div className="text-sm font-medium text-foreground mb-2">
                             Generated Route
                         </div>
                         <EditableOutput

--- a/frontend/src/components/RouteBuilder/RouteBuilderWidget.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilderWidget.tsx
@@ -127,7 +127,7 @@ export function RouteBuilderWidget({
                     />
                     <button
                         onClick={onOpenFullscreen}
-                        className="inline-flex items-center justify-center rounded-md p-1.5 text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-zinc-800 transition-colors"
+                        className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                         title="Open fullscreen map view"
                         aria-label="Open fullscreen map view"
                     >
@@ -153,7 +153,7 @@ export function RouteBuilderWidget({
                 <div className="space-y-6">
                     {/* Location Combobox */}
                     <div>
-                        <span className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2 block">
+                        <span className="text-sm font-medium text-foreground mb-2 block">
                             Select Locations
                         </span>
                         <LocationCombobox
@@ -166,9 +166,9 @@ export function RouteBuilderWidget({
 
                     {/* Selected Locations with Drag & Drop */}
                     {selectedLocationKeys.length > 0 && (
-                        <div className="p-4 bg-slate-50 dark:bg-zinc-800/50 rounded-lg border border-slate-100 dark:border-zinc-700">
+                        <div className="p-4 bg-muted/50 rounded-lg border border-border">
                             <div className="flex items-center justify-between gap-2 mb-3">
-                                <div className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                <div className="text-sm font-medium text-foreground">
                                     Route Order ({selectedLocationKeys.length} location
                                     {selectedLocationKeys.length !== 1 ? 's' : ''})
                                 </div>
@@ -194,7 +194,7 @@ export function RouteBuilderWidget({
 
                     {/* Arrival Time Selection */}
                     <div>
-                        <span className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2 block">
+                        <span className="text-sm font-medium text-foreground mb-2 block">
                             Arrival Time at Final Destination
                         </span>
                         <ArrivalTimeSelector
@@ -208,7 +208,7 @@ export function RouteBuilderWidget({
 
                     {/* Loading indicator */}
                     {routeLoading && (
-                        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
                             <div className="h-4 w-4 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
                             Generating route…
                         </div>
@@ -235,7 +235,7 @@ export function RouteBuilderWidget({
                 {/* Route Output */}
                 {routeOutput && (
                     <div className="mt-8 space-y-4 animate-in fade-in slide-in-from-bottom-4 duration-500">
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                        <h3 className="text-lg font-semibold text-foreground">
                             Generated Route
                         </h3>
                         <EditableOutput
@@ -256,7 +256,7 @@ export function RouteBuilderWidget({
                 )}
 
                 {/* Static mini-map */}
-                <div className="mt-6 rounded-lg overflow-hidden border border-slate-200 dark:border-zinc-700 relative z-0">
+                <div className="mt-6 rounded-lg overflow-hidden border border-border relative z-0">
                     <MapContainer
                         center={UCSD_CENTER}
                         zoom={14}

--- a/frontend/src/components/RouteBuilder/routeBuilderShared.tsx
+++ b/frontend/src/components/RouteBuilder/routeBuilderShared.tsx
@@ -74,26 +74,26 @@ export function SortableLocationItem({
             {legLabel && index > 0 && (
                 <div
                     aria-hidden="true"
-                    className="my-1 ml-6 text-[11px] font-medium text-slate-500 dark:text-slate-400"
+                    className="my-1 ml-6 text-[11px] font-medium text-muted-foreground"
                 >
                     {legLabel}
                 </div>
             )}
-            <div className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-700 rounded-md transition-all">
+            <div className="flex items-center gap-2 px-3 py-2 bg-card border border-border rounded-md transition-all">
                 <div
                     {...attributes}
                     {...listeners}
                     className="cursor-grab active:cursor-grabbing touch-none"
                 >
-                    <GripVertical className="h-4 w-4 text-slate-400" />
+                    <GripVertical className="h-4 w-4 text-muted-foreground" />
                 </div>
-                <span className="flex-1 text-sm text-slate-900 dark:text-slate-100">
+                <span className="flex-1 text-sm text-foreground">
                     {index + 1}. {locationValue}
                 </span>
                 <button
                     type="button"
                     onClick={onRemove}
-                    className="text-slate-400 hover:text-red-500 transition-colors"
+                    className="text-muted-foreground hover:text-destructive transition-colors"
                     title="Remove location"
                 >
                     <X className="h-4 w-4" />
@@ -192,8 +192,8 @@ export function ArrivalTimeSelector({
                             type="button"
                             onClick={() => onTimeModeChange(opt.key, opt.time)}
                             className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${timeMode === opt.key
-                                ? 'bg-slate-900 text-white border-slate-900 dark:bg-white dark:text-slate-900 dark:border-white'
-                                : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50 dark:bg-zinc-800 dark:text-slate-300 dark:border-zinc-600 dark:hover:bg-zinc-700'
+                                ? 'bg-primary text-primary-foreground border-primary'
+                                : 'bg-card text-foreground border-border hover:bg-muted'
                                 }`}
                         >
                             {opt.shortLabel}
@@ -237,7 +237,7 @@ export function ArrivalTimeSelector({
                         required
                         className="w-full max-w-md"
                     />
-                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                    <p className="text-xs text-muted-foreground mt-1">
                         Supports formats: "7:10pm", "7p", "19:10"
                     </p>
                 </div>

--- a/frontend/src/components/SystemActions.tsx
+++ b/frontend/src/components/SystemActions.tsx
@@ -25,10 +25,10 @@ function SystemActions() {
         <SectionCard
             icon="⚠️"
             title="System Actions"
-            titleClassName="text-red-600 dark:text-red-400"
+            titleClassName="text-destructive-text"
         >
                 <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-                    <div className="text-sm text-slate-600 dark:text-slate-400 text-center sm:text-left">
+                    <div className="text-sm text-muted-foreground text-center sm:text-left">
                         Clear all cached data. This will force the system to fetch fresh data from the database and other external sources on the next request. This may temporarily increase load times.
                     </div>
                     <Button

--- a/frontend/src/components/TutorialComponents.tsx
+++ b/frontend/src/components/TutorialComponents.tsx
@@ -8,7 +8,7 @@ interface TutorialSectionProps {
 export function TutorialSection({ title, children }: TutorialSectionProps) {
     return (
         <section className="mb-12">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
+            <h2 className="text-2xl font-bold text-foreground mb-4">
                 {title}
             </h2>
             {children}
@@ -22,7 +22,7 @@ interface TutorialSubheaderProps {
 
 export function TutorialSubheader({ children }: TutorialSubheaderProps) {
     return (
-        <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-200 mt-6 mb-3">
+        <h3 className="text-xl font-semibold text-foreground mt-6 mb-3">
             {children}
         </h3>
     )
@@ -34,7 +34,7 @@ interface TutorialTextProps {
 
 export function TutorialText({ children }: TutorialTextProps) {
     return (
-        <p className="text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
+        <p className="text-muted-foreground leading-relaxed mb-4">
             {children}
         </p>
     )
@@ -46,7 +46,7 @@ interface TutorialListProps {
 
 export function TutorialList({ children }: TutorialListProps) {
     return (
-        <ul className="list-disc pl-6 text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
+        <ul className="list-disc pl-6 text-muted-foreground leading-relaxed mb-4">
             {children}
         </ul>
     )
@@ -62,7 +62,7 @@ export function TutorialTable({ headers, rows }: TutorialTableProps) {
         <div className="overflow-x-auto mt-4 mb-4">
             <table className="w-full border-collapse text-sm text-left">
                 <thead>
-                    <tr className="border-b border-slate-300 dark:border-zinc-700">
+                    <tr className="border-b border-border">
                         {headers.map((header, i) => (
                             <th key={i} className="py-2 px-4 font-semibold">{header}</th>
                         ))}
@@ -70,7 +70,7 @@ export function TutorialTable({ headers, rows }: TutorialTableProps) {
                 </thead>
                 <tbody>
                     {rows.map((row, i) => (
-                        <tr key={i} className="border-b border-slate-200 dark:border-zinc-800">
+                        <tr key={i} className="border-b border-border">
                             {row.map((cell, j) => (
                                 <td key={j} className="py-2 px-4">{cell}</td>
                             ))}

--- a/frontend/src/components/mode-toggle.tsx
+++ b/frontend/src/components/mode-toggle.tsx
@@ -6,14 +6,14 @@ export function ModeToggle() {
     const { setTheme, theme } = useTheme()
 
     return (
-        <div className="flex items-center gap-1 p-1 bg-slate-100 dark:bg-zinc-800 rounded-lg border border-slate-200 dark:border-zinc-700">
+        <div className="flex items-center gap-1 p-1 bg-muted rounded-lg border border-border">
             <Button
                 variant="ghost"
                 size="icon"
                 onClick={() => setTheme("light")}
                 className={`h-8 w-8 rounded-md transition-all ${theme === "light"
-                    ? "bg-white text-slate-900 shadow-sm dark:bg-zinc-600 dark:text-slate-100"
-                    : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
                     }`}
                 title="Light Mode"
             >
@@ -25,8 +25,8 @@ export function ModeToggle() {
                 size="icon"
                 onClick={() => setTheme("system")}
                 className={`h-8 w-8 rounded-md transition-all ${theme === "system"
-                    ? "bg-white text-slate-900 shadow-sm dark:bg-zinc-600 dark:text-slate-100"
-                    : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
                     }`}
                 title="System (Auto)"
             >
@@ -38,8 +38,8 @@ export function ModeToggle() {
                 size="icon"
                 onClick={() => setTheme("dark")}
                 className={`h-8 w-8 rounded-md transition-all ${theme === "dark"
-                    ? "bg-white text-slate-900 shadow-sm dark:bg-zinc-600 dark:text-slate-100"
-                    : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
                     }`}
                 title="Dark Mode"
             >

--- a/frontend/src/components/shared/PageHeader.tsx
+++ b/frontend/src/components/shared/PageHeader.tsx
@@ -30,12 +30,12 @@ function PageHeader({
         <header className="flex flex-col md:flex-row md:items-start md:justify-between gap-6 mb-12">
             <div className={`flex-1 ${titleAlign}`}>
                 {eyebrow}
-                <h1 className="text-4xl font-extrabold tracking-tight text-slate-900 dark:text-white sm:text-5xl mb-4">
+                <h1 className="text-4xl font-extrabold tracking-tight text-foreground sm:text-5xl mb-4">
                     {title}
                 </h1>
                 {description != null && (
                     <p
-                        className={`text-lg text-slate-600 dark:text-slate-400 max-w-2xl ${descriptionAlign}`.trim()}
+                        className={`text-lg text-muted-foreground max-w-2xl ${descriptionAlign}`.trim()}
                     >
                         {description}
                     </p>

--- a/frontend/src/components/shared/PageLayout.tsx
+++ b/frontend/src/components/shared/PageLayout.tsx
@@ -20,7 +20,7 @@ function PageLayout({ header, spacedBody = false, children }: PageLayoutProps) {
             <EnvironmentBanner />
             <main
                 id="main-content"
-                className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-gray-50 dark:bg-zinc-950 py-12 px-4 font-sans text-slate-900 dark:text-slate-100 transition-colors duration-300"
+                className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-background py-12 px-4 font-sans text-foreground transition-colors duration-300"
             >
                 <div
                     className={

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -21,7 +21,7 @@ createRoot(document.getElementById('root')!).render(
       <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
         <ErrorBoundary>
           <BrowserRouter>
-            <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-slate-500">Loading…</div>}>
+            <Suspense fallback={<div className="min-h-screen flex items-center justify-center text-muted-foreground">Loading…</div>}>
               <Routes>
                 <Route path="/login" element={<Login />} />
                 <Route element={<AuthGuard />}>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -50,14 +50,14 @@ function Home() {
                             <div className="flex flex-wrap justify-center md:justify-end gap-2">
                                 <Link
                                     to="/reaction-log"
-                                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 bg-white dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg hover:bg-slate-50 dark:hover:bg-zinc-700 transition-colors"
+                                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-foreground bg-card border border-border rounded-lg hover:bg-muted transition-colors"
                                 >
                                     <History className="w-4 h-4" />
                                     Reaction Log
                                 </Link>
                                 <Link
                                     to="/learn"
-                                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 bg-white dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg hover:bg-slate-50 dark:hover:bg-zinc-700 transition-colors"
+                                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-foreground bg-card border border-border rounded-lg hover:bg-muted transition-colors"
                                 >
                                     <BookOpen className="w-4 h-4" />
                                     Learn
@@ -66,7 +66,7 @@ function Home() {
                                 {!isLocal && (
                                     <button
                                         onClick={() => logout()}
-                                        className="inline-flex items-center px-3 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+                                        className="inline-flex items-center px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
                                         title={meData?.email ?? ''}
                                     >
                                         Sign out
@@ -88,7 +88,7 @@ function Home() {
                     <RouteBuilder />
                     <MapLinks />
                     {isAdmin && (
-                        <Suspense fallback={<div className="text-center py-8 text-slate-500">Loading admin tools…</div>}>
+                        <Suspense fallback={<div className="text-center py-8 text-muted-foreground">Loading admin tools…</div>}>
                             <FeatureFlagsManager />
                             <UserManagement />
                             <SystemActions />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -27,19 +27,19 @@ function Login() {
     }, [])
 
     return (
-        <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-zinc-950 px-4">
+        <div className="min-h-screen flex items-center justify-center bg-background px-4">
             <div className="w-full max-w-sm space-y-6">
                 <div className="text-center space-y-2">
-                    <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-50">
+                    <h1 className="text-2xl font-bold text-foreground">
                         🚗 Rides Dashboard
                     </h1>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                    <p className="text-sm text-muted-foreground">
                         Sign in to continue
                     </p>
                 </div>
 
                 {errorMessage && (
-                    <div className="px-4 py-3 rounded-lg bg-destructive/15 border border-destructive/30 text-sm text-center text-red-700 dark:text-red-400">
+                    <div className="px-4 py-3 rounded-lg bg-destructive/15 border border-destructive/30 text-sm text-center text-destructive-text">
                         {errorMessage}
                     </div>
                 )}
@@ -57,7 +57,7 @@ function Login() {
                 {bypassEnabled && (
                     <a
                         href={getApiUrl('/api/auth/bypass-login')}
-                        className="flex items-center justify-center w-full px-4 py-3 rounded-lg border border-slate-300 dark:border-zinc-700 text-slate-700 dark:text-slate-300 font-medium hover:bg-slate-100 dark:hover:bg-zinc-800 transition-colors"
+                        className="flex items-center justify-center w-full px-4 py-3 rounded-lg border border-border text-foreground font-medium hover:bg-muted transition-colors"
                     >
                         Login
                     </a>

--- a/frontend/src/pages/ReactionLog.tsx
+++ b/frontend/src/pages/ReactionLog.tsx
@@ -119,13 +119,13 @@ function buildQueryString(filters: Filters): string {
 function ActionBadge({ action }: { action: EventAction }) {
     if (action === 'add') {
         return (
-            <span className="inline-flex items-center justify-center w-20 px-2 py-0.5 rounded text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300">
+            <span className="inline-flex items-center justify-center w-20 px-2 py-0.5 rounded text-xs font-semibold bg-success/15 text-success-text">
                 Reacted
             </span>
         )
     }
     return (
-        <span className="inline-flex items-center justify-center w-20 px-2 py-0.5 rounded text-xs font-semibold bg-slate-100 text-slate-500 dark:bg-zinc-800 dark:text-zinc-400">
+        <span className="inline-flex items-center justify-center w-20 px-2 py-0.5 rounded text-xs font-semibold bg-muted text-muted-foreground">
             Removed
         </span>
     )


### PR DESCRIPTION
Replace all instances of bg-slate-*, text-slate-*, bg-zinc-*, text-green-*, bg-red-*, bg-blue-*, etc. with the OKLCH semantic tokens already defined in index.css (text-foreground, text-muted-foreground, bg-muted, bg-card, bg-info/*, bg-success/*, bg-destructive/*, text-info-text, text-success-text, text-destructive-text, border-border). Covers 27 files across pages, components, and RouteBuilder. Closes the last two open items from the designer-frontend-audit.
