### PR TITLE
refactor: extract magic numbers into named constants

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -21,6 +21,7 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from api.auth import cloudflare_access_middleware
 from api.auth_session import session_cookie_middleware
+from api.constants import CORS_LOCALHOST_5173, CORS_LOCALHOST_5174
 from api.middleware.access_logger import AccessLogMiddleware
 from api.rate_limit import limiter
 from api.routes.admin_users import router as admin_users_router
@@ -123,7 +124,7 @@ logger.info("Access logging middleware enabled")
 if APP_ENV == "local":
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:5173", "http://localhost:5174"],  # Vite dev server
+        allow_origins=[CORS_LOCALHOST_5173, CORS_LOCALHOST_5174],  # Vite dev server
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -14,6 +14,7 @@ import httpx
 from fastapi import HTTPException, Request, Response
 from jose import jwt
 
+from api.constants import CF_KEYS_CACHE_TTL_SECONDS, CF_KEYS_HTTP_TIMEOUT
 from bot.core.enums import AccountRoles
 from bot.core.logger import generate_txn_id, txn_id_var, user_email_var
 from bot.services.user_accounts_service import UserAccountsService
@@ -28,7 +29,6 @@ APP_ENV = os.getenv("APP_ENV", "local")
 # Cache for Cloudflare public keys — refreshed every hour
 _cloudflare_keys = None
 _cloudflare_keys_fetched_at: float = 0.0
-_CLOUDFLARE_KEYS_TTL = 3600.0
 
 
 async def get_cloudflare_keys():
@@ -39,13 +39,16 @@ async def get_cloudflare_keys():
         List of public keys or empty list if fetch fails.
     """
     global _cloudflare_keys, _cloudflare_keys_fetched_at
-    if _cloudflare_keys is None or time.time() - _cloudflare_keys_fetched_at > _CLOUDFLARE_KEYS_TTL:
+    if (
+        _cloudflare_keys is None
+        or time.time() - _cloudflare_keys_fetched_at > CF_KEYS_CACHE_TTL_SECONDS
+    ):
         if not CLOUDFLARE_TEAM_DOMAIN:
             logger.warning("CLOUDFLARE_TEAM_DOMAIN environment variable is not set")
             return []
         url = f"https://{CLOUDFLARE_TEAM_DOMAIN}/cdn-cgi/access/certs"
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with httpx.AsyncClient(timeout=CF_KEYS_HTTP_TIMEOUT) as client:
                 resp = await client.get(url)
                 resp.raise_for_status()
                 _cloudflare_keys = resp.json()["keys"]

--- a/backend/api/auth_session.py
+++ b/backend/api/auth_session.py
@@ -13,6 +13,7 @@ import os
 
 from fastapi import Request, Response
 
+from api.constants import CSRF_HEADER_NAME, SESSION_COOKIE_NAME
 from bot.core.database import AsyncSessionLocal
 from bot.core.logger import generate_txn_id, txn_id_var, user_email_var
 from bot.services.auth_service import AuthService
@@ -23,8 +24,7 @@ APP_ENV = os.getenv("APP_ENV", "local")
 # Set LOCAL_USE_DISCORD_OAUTH=true to test real Discord OAuth flow in local dev.
 # When false (default), all requests get the dev@example.com mock user.
 LOCAL_USE_DISCORD_OAUTH = os.getenv("LOCAL_USE_DISCORD_OAUTH", "false").lower() == "true"
-SESSION_COOKIE_NAME = "rides_session"
-CSRF_HEADER = "X-CSRF-Token"
+CSRF_HEADER = CSRF_HEADER_NAME
 SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
 
 # Paths that don't require a session (OAuth flow + health check).

--- a/backend/api/constants.py
+++ b/backend/api/constants.py
@@ -7,3 +7,55 @@ Centralized configuration constants for the API layer.
 import os
 
 ADMIN_EMAILS = {e.strip() for e in os.getenv("ADMIN_EMAILS", "").split(",") if e.strip()}
+
+# Server
+API_HOST = "0.0.0.0"
+API_PORT = 8000
+
+# CORS
+CORS_LOCALHOST_5173 = "http://localhost:5173"
+CORS_LOCALHOST_5174 = "http://localhost:5174"
+
+# Cloudflare auth
+CF_KEYS_CACHE_TTL_SECONDS = 3600.0
+CF_KEYS_HTTP_TIMEOUT = 10.0
+
+# Rate limits
+DEFAULT_RATE_LIMIT = "120/minute"
+GROUP_RIDES_RATE_LIMIT = "10/minute"
+
+# Session / cookies
+SESSION_COOKIE_NAME = "rides_session"
+CSRF_COOKIE_NAME = "csrf_token"
+CSRF_HEADER_NAME = "X-CSRF-Token"
+SESSION_TTL_DAYS = 30
+SESSION_TTL_SECONDS = SESSION_TTL_DAYS * 24 * 60 * 60
+
+# OAuth state cookie
+OAUTH_STATE_COOKIE_MAX_AGE = 600  # 10 minutes
+
+# Discord API URLs
+DISCORD_OAUTH_AUTH_URL = "https://discord.com/api/oauth2/authorize"
+DISCORD_OAUTH_TOKEN_URL = "https://discord.com/api/oauth2/token"
+DISCORD_USER_INFO_URL = "https://discord.com/api/users/@me"
+DISCORD_HTTP_TIMEOUT = 10.0
+
+# Emergency bypass
+BYPASS_SESSION_TTL = 24 * 60 * 60  # 24 hours
+
+# Access log rotation
+ACCESS_LOG_MAX_BYTES = 20 * 1024 * 1024  # 20 MB
+ACCESS_LOG_BACKUP_COUNT = 10
+
+# SSE
+SSE_HEARTBEAT_INTERVAL = 30  # seconds
+
+# Ask rides defaults
+ASK_RIDES_DEFAULT_COUNT = 6
+ASK_RIDES_DEFAULT_OFFSET = 0
+
+# Group rides defaults
+GROUP_RIDES_DEFAULT_CAPACITY = "44444"
+
+# Frontend URL (local dev default)
+FRONTEND_BASE_URL_LOCAL = "http://localhost:5173"

--- a/backend/api/middleware/access_logger.py
+++ b/backend/api/middleware/access_logger.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from api.constants import ACCESS_LOG_BACKUP_COUNT, ACCESS_LOG_MAX_BYTES
 from bot.core.logger import txn_id_var
 
 # Configure access logger
@@ -28,8 +29,8 @@ ACCESS_LOG_FILE = LOG_DIR / "access.log"
 # Rotating file handler for access logs
 access_file_handler = RotatingFileHandler(
     ACCESS_LOG_FILE,
-    maxBytes=20 * 1024 * 1024,  # 20 MB (access logs can be larger)
-    backupCount=10,  # Keep more history for access logs
+    maxBytes=ACCESS_LOG_MAX_BYTES,  # 20 MB (access logs can be larger)
+    backupCount=ACCESS_LOG_BACKUP_COUNT,  # Keep more history for access logs
     encoding="utf-8",
 )
 

--- a/backend/api/rate_limit.py
+++ b/backend/api/rate_limit.py
@@ -10,6 +10,8 @@ client cannot monopolize expensive endpoints (e.g. the LLM-backed
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from api.constants import DEFAULT_RATE_LIMIT
+
 # Default limit applies to every route that uses `limiter.limit(...)` without
 # overriding. Individual routes can apply tighter limits via decorators.
-limiter = Limiter(key_func=get_remote_address, default_limits=["120/minute"])
+limiter = Limiter(key_func=get_remote_address, default_limits=[DEFAULT_RATE_LIMIT])

--- a/backend/api/routes/ask_rides.py
+++ b/backend/api/routes/ask_rides.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from api.auth import require_ride_coordinator
+from api.constants import ASK_RIDES_DEFAULT_COUNT, ASK_RIDES_DEFAULT_OFFSET
 from api.dependencies import require_bot, require_ready_bot
 from bot.core.enums import AskRidesMessage, CacheNamespace, DaysOfWeek, JobName
 from bot.jobs.ask_rides import get_ask_rides_status, run_ask_rides_all
@@ -158,7 +159,9 @@ async def set_pause(job_name: str, request: PauseRequest):
     summary="Get Upcoming Dates",
     description="Get the mathematically projected upcoming event dates for a given job type.",
 )
-async def get_upcoming_dates(job_name: str, count: int = 6, offset: int = 0):
+async def get_upcoming_dates(
+    job_name: str, count: int = ASK_RIDES_DEFAULT_COUNT, offset: int = ASK_RIDES_DEFAULT_OFFSET
+):
     """
     Get upcoming event dates for a job type.
 

--- a/backend/api/routes/auth_bypass.py
+++ b/backend/api/routes/auth_bypass.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from api.constants import BYPASS_SESSION_TTL, CSRF_COOKIE_NAME, SESSION_COOKIE_NAME
 from bot.core.database import AsyncSessionLocal
 from bot.repositories.user_accounts_repository import UserAccountsRepository
 from bot.services.auth_service import AuthService
@@ -26,10 +27,10 @@ BYPASS_DISCORD = os.getenv("BYPASS_DISCORD", "").lower() == "true"
 BYPASS_PASSWORD_HASH = os.getenv("BYPASS_PASSWORD", "")
 BYPASS_EMAIL = os.getenv("BYPASS_EMAIL", "bypass-emergency@local")
 
-SESSION_COOKIE = "rides_session"
-CSRF_COOKIE = "csrf_token"
+SESSION_COOKIE = SESSION_COOKIE_NAME
+CSRF_COOKIE = CSRF_COOKIE_NAME
 _IS_PROD = APP_ENV != "local"
-_COOKIE_TTL = 24 * 60 * 60  # 24 hours — shared credential, shorter TTL limits blast radius
+_COOKIE_TTL = BYPASS_SESSION_TTL  # 24 hours — shared credential, shorter TTL limits blast radius
 
 
 class BypassLoginRequest(BaseModel):

--- a/backend/api/routes/auth_discord.py
+++ b/backend/api/routes/auth_discord.py
@@ -15,6 +15,17 @@ import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 
+from api.constants import (
+    CSRF_COOKIE_NAME,
+    DISCORD_HTTP_TIMEOUT,
+    DISCORD_OAUTH_AUTH_URL,
+    DISCORD_OAUTH_TOKEN_URL,
+    DISCORD_USER_INFO_URL,
+    FRONTEND_BASE_URL_LOCAL,
+    OAUTH_STATE_COOKIE_MAX_AGE,
+    SESSION_COOKIE_NAME,
+    SESSION_TTL_SECONDS,
+)
 from bot.core.database import AsyncSessionLocal
 from bot.services.auth_service import AuthService
 
@@ -26,15 +37,15 @@ APP_ENV = os.getenv("APP_ENV", "local")
 DISCORD_CLIENT_ID = os.getenv("DISCORD_OAUTH_CLIENT_ID")
 DISCORD_CLIENT_SECRET = os.getenv("DISCORD_OAUTH_CLIENT_SECRET")
 DISCORD_REDIRECT_URI = os.getenv("DISCORD_OAUTH_REDIRECT_URI")
-FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "http://localhost:5173")
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", FRONTEND_BASE_URL_LOCAL)
 DISCORD_GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 DISCORD_RIDE_COORDINATOR_ROLE_ID = os.getenv("DISCORD_RIDE_COORDINATOR_ROLE_ID")
-_DISCORD_AUTH_URL = "https://discord.com/api/oauth2/authorize"
-_DISCORD_TOKEN_URL = "https://discord.com/api/oauth2/token"
-_DISCORD_USER_URL = "https://discord.com/api/users/@me"
+_DISCORD_AUTH_URL = DISCORD_OAUTH_AUTH_URL
+_DISCORD_TOKEN_URL = DISCORD_OAUTH_TOKEN_URL
+_DISCORD_USER_URL = DISCORD_USER_INFO_URL
 
-SESSION_COOKIE = "rides_session"
-CSRF_COOKIE = "csrf_token"
+SESSION_COOKIE = SESSION_COOKIE_NAME
+CSRF_COOKIE = CSRF_COOKIE_NAME
 _IS_PROD = APP_ENV != "local"
 
 
@@ -62,7 +73,7 @@ async def discord_login() -> RedirectResponse:
     response.set_cookie(
         "oauth_state",
         state,
-        max_age=600,
+        max_age=OAUTH_STATE_COOKIE_MAX_AGE,
         httponly=True,
         samesite="lax",
         path="/api/auth/discord/callback",
@@ -101,7 +112,7 @@ async def discord_callback(
         return _login_error_redirect("server_misconfigured")
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=DISCORD_HTTP_TIMEOUT) as client:
             token_resp = await client.post(
                 _DISCORD_TOKEN_URL,
                 data={
@@ -197,7 +208,7 @@ async def discord_callback(
     logger.info("Login successful: discord_username=%s email=%s", discord_username, account.email)
     response = RedirectResponse(FRONTEND_BASE_URL)
     response.delete_cookie("oauth_state", path="/api/auth/discord/callback")
-    _cookie_ttl = 30 * 24 * 60 * 60  # 30 days in seconds
+    _cookie_ttl = SESSION_TTL_SECONDS  # 30 days in seconds
     response.set_cookie(
         SESSION_COOKIE,
         session_id_plain,

--- a/backend/api/routes/group_rides.py
+++ b/backend/api/routes/group_rides.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from api.constants import GROUP_RIDES_DEFAULT_CAPACITY, GROUP_RIDES_RATE_LIMIT
 from api.dependencies import parse_int_param, require_bot, validate_ride_type
 from api.rate_limit import limiter
 from bot.core.enums import ChannelIds, JobName
@@ -23,7 +24,8 @@ class GroupRidesRequest(BaseModel):
         default=None, description="Required only when ride_type is 'message_id'"
     )
     driver_capacity: str = Field(
-        default="44444", description="String of integers representing seats per driver"
+        default=GROUP_RIDES_DEFAULT_CAPACITY,
+        description="String of integers representing seats per driver",
     )
     channel_id: str = Field(
         default=str(int(ChannelIds.REFERENCES__RIDES_ANNOUNCEMENTS)),
@@ -50,7 +52,7 @@ class GroupRidesResponse(BaseModel):
     summary="Group Rides",
     description="Automatically group people from pickup locations into cars based on driver capacity.",
 )
-@limiter.limit("10/minute")
+@limiter.limit(GROUP_RIDES_RATE_LIMIT)
 async def group_rides(request: Request, body: GroupRidesRequest):
     """
     Group rides based on ride type (Friday, Sunday, or custom message ID).

--- a/backend/api/routes/reaction_log_stream.py
+++ b/backend/api/routes/reaction_log_stream.py
@@ -12,13 +12,14 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
 from api.auth import require_ride_coordinator
+from api.constants import SSE_HEARTBEAT_INTERVAL
 from bot.core import reaction_broadcaster
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_HEARTBEAT_INTERVAL = 30
+_HEARTBEAT_INTERVAL = SSE_HEARTBEAT_INTERVAL
 
 
 @router.get(

--- a/backend/bot/cogs/group_rides.py
+++ b/backend/bot/cogs/group_rides.py
@@ -9,6 +9,7 @@ from bot.core.logger import log_cmd
 from bot.services.group_rides_service import GroupRidesService
 from bot.utils.channel_whitelist import LOCATIONS_CHANNELS_WHITELIST, cmd_is_allowed
 from bot.utils.checks import feature_flag_enabled
+from bot.utils.constants import GROUP_RIDES_DEFAULT_CAPACITY
 
 
 class GroupRides(commands.Cog):
@@ -31,7 +32,7 @@ class GroupRides(commands.Cog):
     async def group_rides_friday(
         self,
         interaction: discord.Interaction,
-        driver_capacity: str = "44444",
+        driver_capacity: str = GROUP_RIDES_DEFAULT_CAPACITY,
         custom_prompt: str | None = None,
         legacy_prompt: bool = False,
     ):
@@ -68,7 +69,7 @@ class GroupRides(commands.Cog):
     async def group_rides_sunday(
         self,
         interaction: discord.Interaction,
-        driver_capacity: str = "44444",
+        driver_capacity: str = GROUP_RIDES_DEFAULT_CAPACITY,
         custom_prompt: str | None = None,
         legacy_prompt: bool = False,
     ):
@@ -106,7 +107,7 @@ class GroupRides(commands.Cog):
         self,
         interaction: discord.Interaction,
         message_id: str,
-        driver_capacity: str = "44444",
+        driver_capacity: str = GROUP_RIDES_DEFAULT_CAPACITY,
         legacy_prompt: bool = False,
     ):
         """

--- a/backend/bot/core/lifecycle.py
+++ b/backend/bot/core/lifecycle.py
@@ -24,6 +24,7 @@ from bot.core.database import (
 )
 from bot.core.models import FeatureFlags
 from bot.repositories.feature_flags_repository import FeatureFlagsRepository
+from bot.utils.constants import REDIS_CONNECTION_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ async def startup() -> None:
 
         backend = RedisBackend(redis_url)
         try:
-            await asyncio.wait_for(backend._redis.ping(), timeout=5.0)
+            await asyncio.wait_for(backend._redis.ping(), timeout=REDIS_CONNECTION_TIMEOUT)
             logger.info("Redis connection established")
             set_backend(backend)
         except Exception:

--- a/backend/bot/jobs/ask_rides.py
+++ b/backend/bot/jobs/ask_rides.py
@@ -31,6 +31,12 @@ from bot.repositories.feature_flags_repository import FeatureFlagsRepository
 from bot.repositories.message_schedule_repository import MessageScheduleRepository
 from bot.utils.cache import alru_cache, warm_ask_drivers_message_cache, warm_ask_rides_message_cache
 from bot.utils.checks import feature_flag_enabled
+from bot.utils.constants import (
+    ASK_RIDES_ACTIVE_CACHE_TTL,
+    ASK_RIDES_HOURLY_CACHE_TTL,
+    ASK_RIDES_MESSAGE_HISTORY_LIMIT,
+    ASK_RIDES_OFF_HOURS_CACHE_TTL,
+)
 from bot.utils.format_message import ping_role_with_message, ping_user
 from bot.utils.time_helpers import (
     get_current_cycle_start,
@@ -89,12 +95,12 @@ def _get_dynamic_ttl() -> int:
 
     # Wednesday is weekday 2 (0=Monday) — extra-short TTL around message send time
     if now.weekday() == 2 and 11 <= now.hour < 13:
-        return 60  # Short TTL during active period
+        return ASK_RIDES_ACTIVE_CACHE_TTL  # Short TTL during active period
 
     if is_active_hours():
-        return 60 * 60  # 1 hour during active hours
+        return ASK_RIDES_HOURLY_CACHE_TTL  # 1 hour during active hours
 
-    return 7 * 60 * 60  # 7 hours during off-hours
+    return ASK_RIDES_OFF_HOURS_CACHE_TTL  # 7 hours during off-hours
 
 
 def _make_wednesday_msg() -> str | None:
@@ -534,7 +540,7 @@ async def get_ask_rides_status(bot: Bot) -> dict:
             current_week_start = get_current_cycle_start()
 
             # Fetch recent messages (last 20)
-            messages = [msg async for msg in channel.history(limit=20)]
+            messages = [msg async for msg in channel.history(limit=ASK_RIDES_MESSAGE_HISTORY_LIMIT)]
 
             friday_last_msg = await find_message_in_history(
                 messages, JobName.FRIDAY, current_week_start

--- a/backend/bot/repositories/ride_coverage_repository.py
+++ b/backend/bot/repositories/ride_coverage_repository.py
@@ -7,6 +7,7 @@ from sqlalchemy import delete, distinct, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.core.models import RideCoverage as RideCoverageModel
+from bot.utils.constants import COVERAGE_STATUS_DEFAULT_HOURS
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class RideCoverageRepository:
 
     @staticmethod
     async def get_coverage_status(
-        session: AsyncSession, discord_username: str, hours: int = 24
+        session: AsyncSession, discord_username: str, hours: int = COVERAGE_STATUS_DEFAULT_HOURS
     ) -> bool:
         """
         Checks if a ride coverage entry exists for the user within the last X hours.
@@ -72,7 +73,7 @@ class RideCoverageRepository:
     async def get_bulk_coverage_status(
         session: AsyncSession,
         discord_usernames: list[str],
-        hours: int = 24,
+        hours: int = COVERAGE_STATUS_DEFAULT_HOURS,
         since: datetime.datetime | None = None,
     ) -> set[str]:
         """

--- a/backend/bot/services/auth_service.py
+++ b/backend/bot/services/auth_service.py
@@ -16,9 +16,7 @@ from bot.core.enums import AccountRoles
 from bot.core.models import AuthSession, UserAccount
 from bot.repositories.auth_sessions_repository import AuthSessionsRepository
 from bot.repositories.user_accounts_repository import UserAccountsRepository
-
-SESSION_TTL_DAYS = 30
-TOUCH_THROTTLE_MINUTES = 5
+from bot.utils.constants import SESSION_TOUCH_THROTTLE_MINUTES, SESSION_TTL_DAYS
 
 
 def _hash_token(token: str) -> str:
@@ -119,7 +117,9 @@ class AuthService:
     ) -> None:
         """Slide the session expiry if it hasn't been touched recently."""
         now = datetime.utcnow()
-        if (now - auth_session.last_activity_at) < timedelta(minutes=TOUCH_THROTTLE_MINUTES):
+        if (now - auth_session.last_activity_at) < timedelta(
+            minutes=SESSION_TOUCH_THROTTLE_MINUTES
+        ):
             return
         new_expires = now + timedelta(days=SESSION_TTL_DAYS)
         session_id_hash = _hash_token(session_id_plain)

--- a/backend/bot/services/llm_service.py
+++ b/backend/bot/services/llm_service.py
@@ -8,6 +8,13 @@ import tenacity
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from bot.core.schemas import LLMOutputError, LLMOutputNominal
+from bot.utils.constants import (
+    GEMINI_MODEL,
+    LLM_JSON_CODEBOX_END_OFFSET,
+    LLM_JSON_CODEBOX_START_OFFSET,
+    LLM_RETRY_ATTEMPTS,
+    LLM_RETRY_WAIT_SECONDS,
+)
 from bot.utils.genai.prompt import (
     CUSTOM_INSTRUCTIONS,
     GROUP_RIDES_PROMPT,
@@ -16,10 +23,6 @@ from bot.utils.genai.prompt import (
 )
 
 logger = logging.getLogger(__name__)
-
-# LLM_MODEL = "gemini-2.5-pro"
-LLM_MODEL = "gemini-2.5-flash"
-NUM_RETRY_ATTEMPTS = 4
 
 
 def log_retry_attempt(retry_state):
@@ -45,11 +48,11 @@ class LLMService:
 
     def __init__(self):
         """Initialize the LLMService."""
-        self.llm = ChatGoogleGenerativeAI(model=LLM_MODEL, temperature=0)
+        self.llm = ChatGoogleGenerativeAI(model=GEMINI_MODEL, temperature=0)
 
     @tenacity.retry(
-        stop=tenacity.stop_after_attempt(NUM_RETRY_ATTEMPTS),
-        wait=tenacity.wait_fixed(5),
+        stop=tenacity.stop_after_attempt(LLM_RETRY_ATTEMPTS),
+        wait=tenacity.wait_fixed(LLM_RETRY_WAIT_SECONDS),
         retry=tenacity.retry_if_exception_type(Exception),
         before_sleep=log_retry_attempt,
     )
@@ -122,10 +125,8 @@ class LLMService:
 
             # Original logic fallback
             if "json" in ai_response.content:
-                codebox_beginning_idx = 8
-                codebox_ending_idx = -3
                 llm_result = json.loads(
-                    ai_response.content[codebox_beginning_idx:codebox_ending_idx]
+                    ai_response.content[LLM_JSON_CODEBOX_START_OFFSET:LLM_JSON_CODEBOX_END_OFFSET]
                 )
             else:
                 llm_result = json.loads(ai_response.content)

--- a/backend/bot/services/ride_grouping.py
+++ b/backend/bot/services/ride_grouping.py
@@ -5,12 +5,10 @@ from datetime import datetime, timedelta
 
 from bot.core.enums import PickupLocations
 from bot.core.schemas import LocationQuery, Passenger
-from bot.utils.constants import get_map_url
+from bot.utils.constants import RIDE_GROUPING_PICKUP_ADJUSTMENT, get_map_url
 from bot.utils.locations import lookup_time
 
 logger = logging.getLogger(__name__)
-
-PICKUP_ADJUSTMENT = 1
 
 LocationsPeopleType = dict[str, list[tuple[str, str]]]
 PassengersByLocation = dict[PickupLocations, list[Passenger]]
@@ -100,7 +98,7 @@ def calculate_pickup_time(
     Returns:
         datetime.time: The calculated pickup time.
     """
-    time_between = PICKUP_ADJUSTMENT + lookup_time(
+    time_between = RIDE_GROUPING_PICKUP_ADJUSTMENT + lookup_time(
         LocationQuery(
             start_location=grouped_by_location[len(grouped_by_location) - offset][
                 0

--- a/backend/bot/services/route_service.py
+++ b/backend/bot/services/route_service.py
@@ -7,8 +7,7 @@ from rapidfuzz import fuzz, process
 
 from bot.core.enums import PickupLocations
 from bot.core.schemas import LocationQuery
-from bot.services.ride_grouping import PICKUP_ADJUSTMENT
-from bot.utils.constants import get_map_url
+from bot.utils.constants import RIDE_GROUPING_PICKUP_ADJUSTMENT, get_map_url
 from bot.utils.locations import lookup_time
 from bot.utils.parsing import parse_time
 
@@ -88,7 +87,7 @@ class RouteService:
         reversed_locations = list(reversed(locations_list_actual))
         for idx, location in enumerate(reversed_locations):
             if idx != 0:
-                time_between = PICKUP_ADJUSTMENT + lookup_time(
+                time_between = RIDE_GROUPING_PICKUP_ADJUSTMENT + lookup_time(
                     LocationQuery(start_location=location, end_location=reversed_locations[idx - 1])
                 )
                 logger.debug(f"{time_between=}")

--- a/backend/bot/utils/cache.py
+++ b/backend/bot/utils/cache.py
@@ -16,6 +16,11 @@ from typing import Any, TypeVar
 
 from bot.core.enums import CacheNamespace, FeatureFlagNames
 from bot.utils.cache_backends import get_backend
+from bot.utils.constants import (
+    CACHE_DEFAULT_MAX_SIZE,
+    REACTION_CACHE_ACTIVE_TTL,
+    REACTION_CACHE_OFF_HOURS_TTL,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,10 +31,6 @@ _namespace_registry: dict[str, list[Callable]] = {}
 
 # Global registry: namespace -> list of (func_name, stats_callable)
 _func_registry: dict[str, list[tuple[str, Callable]]] = {}
-
-# Cache TTL constants (in seconds)
-ACTIVE_HOURS_REACTION_TTL = 65 * 60  # 65 minutes
-OFF_HOURS_REACTION_TTL = 7 * 60 * 60  # 7 hours
 
 
 def _get_reaction_cache_ttl() -> int:
@@ -45,8 +46,8 @@ def _get_reaction_cache_ttl() -> int:
     from bot.utils.time_helpers import is_active_hours
 
     if is_active_hours():
-        return ACTIVE_HOURS_REACTION_TTL
-    return OFF_HOURS_REACTION_TTL
+        return REACTION_CACHE_ACTIVE_TTL
+    return REACTION_CACHE_OFF_HOURS_TTL
 
 
 def _is_cache_enabled() -> bool:
@@ -62,7 +63,7 @@ def _make_cache_key(*args, **kwargs) -> str:
 
 
 def alru_cache(
-    maxsize: int = 128,
+    maxsize: int = CACHE_DEFAULT_MAX_SIZE,
     ttl: int | float | Callable[[], int | float] | None = None,
     ignore_self: bool = False,
     namespace: CacheNamespace = CacheNamespace.DEFAULT,

--- a/backend/bot/utils/constants.py
+++ b/backend/bot/utils/constants.py
@@ -72,3 +72,44 @@ def get_map_links() -> dict[PickupLocations, str]:
         Dictionary mapping PickupLocations to Google Maps URL strings.
     """
     return {loc: get_map_url(loc) for loc in MAP_LOCATIONS}
+
+
+# Session / auth (bot side)
+SESSION_TTL_DAYS = 30
+SESSION_TOUCH_THROTTLE_MINUTES = 5
+
+# LLM
+GEMINI_MODEL = "gemini-2.5-flash"
+LLM_RETRY_ATTEMPTS = 4
+LLM_RETRY_WAIT_SECONDS = 5
+LLM_JSON_CODEBOX_START_OFFSET = 8
+LLM_JSON_CODEBOX_END_OFFSET = -3
+
+# Ride grouping
+RIDE_GROUPING_PICKUP_ADJUSTMENT = 1
+
+# Ride coverage
+COVERAGE_STATUS_DEFAULT_HOURS = 24
+
+# Ask rides job
+ASK_RIDES_ACTIVE_CACHE_TTL = 60  # seconds (during Wednesday active period)
+ASK_RIDES_HOURLY_CACHE_TTL = 60 * 60  # seconds (during active hours)
+ASK_RIDES_OFF_HOURS_CACHE_TTL = 7 * 60 * 60  # seconds (off-hours)
+ASK_RIDES_MESSAGE_HISTORY_LIMIT = 20
+
+# Cache
+CACHE_DEFAULT_MAX_SIZE = 128
+REACTION_CACHE_ACTIVE_TTL = 65 * 60  # 65 minutes
+REACTION_CACHE_OFF_HOURS_TTL = 7 * 60 * 60  # 7 hours
+
+# Time helpers
+DAYS_IN_WEEK = 7
+ACTIVE_HOURS_START = 7  # 7 AM
+ACTIVE_HOURS_END = 1  # 1 AM next day
+RIDE_CYCLE_START_HOUR = 12  # noon
+
+# Lifecycle
+REDIS_CONNECTION_TIMEOUT = 5.0
+
+# Default group rides capacity
+GROUP_RIDES_DEFAULT_CAPACITY = "44444"

--- a/backend/bot/utils/time_helpers.py
+++ b/backend/bot/utils/time_helpers.py
@@ -6,6 +6,12 @@ from datetime import date, datetime, timedelta
 import pytz
 
 from bot.core.enums import DaysOfWeek, DaysOfWeekNumber
+from bot.utils.constants import (
+    ACTIVE_HOURS_END,
+    ACTIVE_HOURS_START,
+    DAYS_IN_WEEK,
+    RIDE_CYCLE_START_HOUR,
+)
 
 LA_TZ = pytz.timezone("America/Los_Angeles")
 
@@ -18,8 +24,6 @@ days_of_week_to_number = {
     DaysOfWeek.SATURDAY: DaysOfWeekNumber.SATURDAY,
     DaysOfWeek.SUNDAY: DaysOfWeekNumber.SUNDAY,
 }
-
-DAYS_IN_WEEK = 7
 
 # ---------------------------------------------------------------------------
 # Unified time-window configuration
@@ -183,11 +187,7 @@ def get_coverage_message_lookup_start(ride_type: str) -> datetime | None:
     )
 
 
-ACTIVE_HOURS_START = 7
-ACTIVE_HOURS_END = 1
-
 RIDE_CYCLE_START_DAY = DaysOfWeekNumber.WEDNESDAY
-RIDE_CYCLE_START_HOUR = 12
 RIDE_CYCLE_END_DAY = DaysOfWeekNumber.SUNDAY
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
 ]
 
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+pythonpath = ["."]
+
 [dependency-groups]
 dev = [
     "invoke>=2.2.0",

--- a/backend/run_api.py
+++ b/backend/run_api.py
@@ -6,5 +6,7 @@ Entry point to run the FastAPI application with integrated Discord bot.
 
 import uvicorn
 
+from api.constants import API_HOST, API_PORT
+
 if __name__ == "__main__":
-    uvicorn.run("api.app:app", host="0.0.0.0", port=8000, reload=False, log_level="info")
+    uvicorn.run("api.app:app", host=API_HOST, port=API_PORT, reload=False, log_level="info")

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -9,7 +9,8 @@ from sqlalchemy.exc import IntegrityError
 
 from bot.core.enums import AccountRoles
 from bot.core.models import AuthSession, UserAccount
-from bot.services.auth_service import TOUCH_THROTTLE_MINUTES, AuthService, _hash_token
+from bot.services.auth_service import AuthService, _hash_token
+from bot.utils.constants import SESSION_TOUCH_THROTTLE_MINUTES
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -355,7 +356,7 @@ async def test_get_session_expired_deletes_and_returns_none():
 
 @pytest.mark.asyncio
 async def test_touch_session_slides_expiry_when_stale():
-    old_activity = datetime.utcnow() - timedelta(minutes=TOUCH_THROTTLE_MINUTES + 1)
+    old_activity = datetime.utcnow() - timedelta(minutes=SESSION_TOUCH_THROTTLE_MINUTES + 1)
     auth_session = _make_session(last_activity_at=old_activity)
     session = AsyncMock()
 

--- a/backend/tests/unit/test_group_rides.py
+++ b/backend/tests/unit/test_group_rides.py
@@ -230,7 +230,9 @@ class TestCalculatePickupTime:
     sample_route_so_far = [[p_warren]]  # noqa
 
     @patch("bot.services.ride_grouping.lookup_time")
-    @patch("bot.services.ride_grouping.PICKUP_ADJUSTMENT", 2)  # Mock the constant to be 2 minutes
+    @patch(
+        "bot.services.ride_grouping.RIDE_GROUPING_PICKUP_ADJUSTMENT", 2
+    )  # Mock the constant to be 2 minutes
     def test_simple_calculation(self, mock_lookup_time):
         """Should correctly calculate a new pickup time by subtracting travel and adjustment time."""
         # Arrange: Mock the travel time between Innovation (the stop we are calculating)

--- a/frontend/src/components/AskRidesDashboard/PauseControls.tsx
+++ b/frontend/src/components/AskRidesDashboard/PauseControls.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { apiFetch } from '../../lib/api'
+import { UPCOMING_DATES_PAGE_SIZE } from '../../lib/constants'
 import { Button } from '../ui/button'
 import {
     Dialog,
@@ -35,7 +36,7 @@ function PauseControls({ jobName, job }: PauseControlsProps) {
     const { data: upcomingDates, isLoading: datesLoading } = useQuery<{ dates: UpcomingDate[]; has_more: boolean }>({
         queryKey: ['upcomingDates', jobName, dateOffset],
         queryFn: async () => {
-            const response = await apiFetch(`/api/ask-rides/upcoming-dates/${jobName}?count=4&offset=${dateOffset}`)
+            const response = await apiFetch(`/api/ask-rides/upcoming-dates/${jobName}?count=${UPCOMING_DATES_PAGE_SIZE}&offset=${dateOffset}`)
             return response.json()
         },
         enabled: showModal,
@@ -123,7 +124,7 @@ function PauseControls({ jobName, job }: PauseControlsProps) {
                                 <Button
                                     variant="ghost"
                                     size="icon-sm"
-                                    onClick={() => setDateOffset((prev) => Math.max(0, prev - 4))}
+                                    onClick={() => setDateOffset((prev) => Math.max(0, prev - UPCOMING_DATES_PAGE_SIZE))}
                                     disabled={dateOffset === 0}
                                     aria-label="Previous dates"
                                 >
@@ -135,7 +136,7 @@ function PauseControls({ jobName, job }: PauseControlsProps) {
                                 <Button
                                     variant="ghost"
                                     size="icon-sm"
-                                    onClick={() => setDateOffset((prev) => prev + 4)}
+                                    onClick={() => setDateOffset((prev) => prev + UPCOMING_DATES_PAGE_SIZE)}
                                     aria-label="Next dates"
                                 >
                                     →

--- a/frontend/src/components/EditableOutput.tsx
+++ b/frontend/src/components/EditableOutput.tsx
@@ -1,6 +1,12 @@
 import { useMemo, useRef, useState } from 'react'
 import { Button } from './ui/button'
 import type { UsernameEntry } from '../hooks/useUsernames'
+import {
+    COPY_FEEDBACK_MS,
+    MENTION_DROPDOWN_MAX_HEIGHT,
+    MENTION_DROPDOWN_LINE_HEIGHT_FALLBACK,
+    MENTION_DROPDOWN_OFFSET,
+} from '../lib/constants'
 
 interface EditableOutputProps {
     value: string
@@ -101,8 +107,8 @@ function measureAtPosition(
 
     const textareaRect = textarea.getBoundingClientRect()
     const containerRect = container.getBoundingClientRect()
-    const lineHeight = parseFloat(cs.lineHeight) || 20
-    const dropdownMaxH = 152
+    const lineHeight = parseFloat(cs.lineHeight) || MENTION_DROPDOWN_LINE_HEIGHT_FALLBACK
+    const dropdownMaxH = MENTION_DROPDOWN_MAX_HEIGHT
 
     // Subtract scrollTop because the textarea may have scrolled.
     const relTop = textareaRect.top - containerRect.top + caretTop - textarea.scrollTop
@@ -110,9 +116,9 @@ function measureAtPosition(
 
     const spaceBelow = containerRect.height - relTop - lineHeight
     if (spaceBelow >= dropdownMaxH || spaceBelow >= relTop) {
-        return { top: relTop + lineHeight + 4, left: relLeft }
+        return { top: relTop + lineHeight + MENTION_DROPDOWN_OFFSET, left: relLeft }
     }
-    return { top: relTop - dropdownMaxH - 4, left: relLeft }
+    return { top: relTop - dropdownMaxH - MENTION_DROPDOWN_OFFSET, left: relLeft }
 }
 
 function EditableOutput({
@@ -276,7 +282,7 @@ function EditableOutput({
                     </Button>
                 )}
                 <Button
-                    onClick={() => { onCopy(); setCopied(true); setTimeout(() => setCopied(false), 2000) }}
+                    onClick={() => { onCopy(); setCopied(true); setTimeout(() => setCopied(false), COPY_FEEDBACK_MS) }}
                     size="sm"
                     variant={copied ? 'default' : 'outline'}
                     className={`h-8 px-2 text-xs bg-card hover:bg-muted ${

--- a/frontend/src/components/MapShared.tsx
+++ b/frontend/src/components/MapShared.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useMap } from 'react-leaflet'
 import L from 'leaflet'
+import { MAP_FIT_BOUNDS_PADDING, MAP_FIT_BOUNDS_DURATION, HINT_MESSAGE_MS } from '../lib/constants'
 
 // Component to recenter map when selected location changes
 export function RecenterMap({ center, zoom = 16, bounds }: { center?: [number, number], zoom?: number, bounds?: L.LatLngBoundsExpression }) {
@@ -8,9 +9,9 @@ export function RecenterMap({ center, zoom = 16, bounds }: { center?: [number, n
 
     useEffect(() => {
         if (bounds) {
-            map.fitBounds(bounds, { padding: [50, 50], duration: 0.8 })
+            map.fitBounds(bounds, { padding: [MAP_FIT_BOUNDS_PADDING, MAP_FIT_BOUNDS_PADDING], duration: MAP_FIT_BOUNDS_DURATION })
         } else if (center) {
-            map.flyTo(center, zoom, { duration: 0.8 })
+            map.flyTo(center, zoom, { duration: MAP_FIT_BOUNDS_DURATION })
         }
     }, [center, zoom, bounds, map])
     return null
@@ -27,7 +28,7 @@ export function MapInteractionGuard() {
     const showHintTemporarily = useCallback(
         (msg: string) => {
             setHintMessage(msg)
-            const id = setTimeout(() => setHintMessage(null), 1500)
+            const id = setTimeout(() => setHintMessage(null), HINT_MESSAGE_MS)
             return () => clearTimeout(id)
         },
         [setHintMessage]

--- a/frontend/src/components/RideCoverageCheck.tsx
+++ b/frontend/src/components/RideCoverageCheck.tsx
@@ -7,6 +7,7 @@ import { InfoToggleButton, InfoPanel } from './InfoHelp'
 import { Button } from './ui/button'
 import { RefreshCw, MoreVertical, CloudDownload, Check } from 'lucide-react'
 import { getAutomaticDay } from '../lib/utils'
+import { QUERY_STALE_5_MIN, COVERAGE_PERCENTAGE_MULTIPLIER } from '../lib/constants'
 import { CoverageSkeleton } from './LoadingSkeleton'
 import { RefreshIconButton, SectionCard } from './shared'
 
@@ -30,7 +31,7 @@ function RideDay({ rideType, title, emoji }: RideDayProps) {
             return response.json()
         },
         // Cache data for 5 minutes to prevent excessive Discord API calls
-        staleTime: 5 * 60 * 1000,
+        staleTime: QUERY_STALE_5_MIN,
         // Disable aggressive refetching to avoid rate limits
         refetchOnWindowFocus: false,
         refetchOnMount: false,
@@ -54,7 +55,7 @@ function RideDay({ rideType, title, emoji }: RideDayProps) {
     }
 
     const percentAssigned = coverage.total > 0
-        ? Math.round((coverage.assigned / coverage.total) * 100)
+        ? Math.round((coverage.assigned / coverage.total) * COVERAGE_PERCENTAGE_MULTIPLIER)
         : 0
 
     return (
@@ -137,7 +138,7 @@ function RideCoverageCheck() {
             const response = await apiFetch(`/api/check-pickups/${currentRideType}`)
             return response.json()
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: QUERY_STALE_5_MIN,
         refetchOnWindowFocus: false,
         refetchOnMount: false,
         refetchOnReconnect: false,

--- a/frontend/src/components/RideCoverageWarning.tsx
+++ b/frontend/src/components/RideCoverageWarning.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from '../lib/api'
 import type { RideCoverage } from '../types'
 import { AlertTriangle } from 'lucide-react'
 import { isFridayWarningWindow, isSundayWarningWindow } from '../lib/utils'
+import { QUERY_STALE_5_MIN } from '../lib/constants'
 
 function RideCoverageWarning() {
     // Check Friday ride coverage
@@ -12,7 +13,7 @@ function RideCoverageWarning() {
             const response = await apiFetch('/api/check-pickups/friday')
             return response.json()
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: QUERY_STALE_5_MIN,
         refetchOnWindowFocus: false,
         refetchOnMount: false,
         refetchOnReconnect: false,
@@ -25,7 +26,7 @@ function RideCoverageWarning() {
             const response = await apiFetch('/api/check-pickups/sunday')
             return response.json()
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: QUERY_STALE_5_MIN,
         refetchOnWindowFocus: false,
         refetchOnMount: false,
         refetchOnReconnect: false,

--- a/frontend/src/components/RouteBuilder/RouteBuilder.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilder.tsx
@@ -29,6 +29,18 @@ import '@luomus/leaflet-smooth-wheel-zoom'
 import { setupLeafletIcons } from '../MapConstants'
 
 import { PRESET_TIME_MAP, PRESET_TIMES, type TimeModeKey } from './routeBuilderConstants'
+import {
+    QUERY_STALE_5_MIN,
+    LOCATION_TOGGLE_DELAY_MS,
+    ROUTE_GENERATION_DEBOUNCE_MS,
+    MAP_PADDING_FRACTION,
+    MAP_PADDING_MIN_DEGREES,
+    ROUTE_BUILDER_STORAGE_KEY,
+    RB_PARAM_STOPS,
+    RB_PARAM_TIME_MODE,
+    RB_PARAM_LEAVE_TIME,
+    RB_PARAM_DRIVER,
+} from '../../lib/constants'
 import { useRouteGeometry } from './useRouteGeometry'
 import { formatDuration, formatTripSummary } from './routeBuilderFormat'
 
@@ -61,13 +73,13 @@ function useIsMobile(breakpoint = 640) {
 // Persistence (localStorage + URL search params)
 // ---------------------------------------------------------------------------
 
-const STORAGE_KEY = 'routeBuilder.state.v1'
+const STORAGE_KEY = ROUTE_BUILDER_STORAGE_KEY
 
 const URL_KEYS = {
-    stops: 'rb_stops',
-    timeMode: 'rb_time_mode',
-    leaveTime: 'rb_leave_time',
-    driver: 'rb_driver',
+    stops: RB_PARAM_STOPS,
+    timeMode: RB_PARAM_TIME_MODE,
+    leaveTime: RB_PARAM_LEAVE_TIME,
+    driver: RB_PARAM_DRIVER,
 } as const
 
 const VALID_TIME_MODES: ReadonlySet<TimeModeKey> = new Set(
@@ -202,7 +214,7 @@ function RouteBuilder() {
             const res = await apiFetch(`/api/check-pickups/driver-reactions/${driverDay}`)
             return res.json()
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: QUERY_STALE_5_MIN,
     })
 
     const uniqueDrivers = driverData
@@ -373,8 +385,8 @@ function RouteBuilder() {
 
         const lats = coords.map((c) => c.lat)
         const lngs = coords.map((c) => c.lng)
-        const latPadding = (Math.max(...lats) - Math.min(...lats)) * 0.1 || 0.01
-        const lngPadding = (Math.max(...lngs) - Math.min(...lngs)) * 0.1 || 0.01
+        const latPadding = (Math.max(...lats) - Math.min(...lats)) * MAP_PADDING_FRACTION || MAP_PADDING_MIN_DEGREES
+        const lngPadding = (Math.max(...lngs) - Math.min(...lngs)) * MAP_PADDING_FRACTION || MAP_PADDING_MIN_DEGREES
 
         setMapBounds([
             [Math.min(...lats) - latPadding, Math.min(...lngs) - lngPadding],
@@ -419,7 +431,7 @@ function RouteBuilder() {
         )
         // Clear after the 0.35s bounce animation so any unrelated re-render
         // (e.g. changing the preset time) doesn't replay the animation.
-        setTimeout(() => setLastToggledLocation(null), 400)
+        setTimeout(() => setLastToggledLocation(null), LOCATION_TOGGLE_DELAY_MS)
     }
 
     const generateRoute = useCallback(async () => {
@@ -460,7 +472,7 @@ function RouteBuilder() {
             setSelectedDriver('')
             return
         }
-        const timer = setTimeout(() => generateRoute(), 300)
+        const timer = setTimeout(() => generateRoute(), ROUTE_GENERATION_DEBOUNCE_MS)
         return () => clearTimeout(timer)
     }, [selectedLocationKeys, leaveTime, generateRoute])
 

--- a/frontend/src/components/RouteBuilder/RouteBuilderFullscreenMap.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilderFullscreenMap.tsx
@@ -14,6 +14,14 @@ import '@luomus/leaflet-smooth-wheel-zoom'
 import { UCSD_CENTER } from '../MapConstants'
 import { createNumberedIcon, defaultMarkerIcon } from './numberedMarker'
 import type { PickupLocationsResponse } from '../../types'
+import {
+    MAP_INITIAL_ZOOM,
+    MAP_SMOOTH_WHEEL_ZOOM,
+    TOOLTIP_OFFSET_SELECTED,
+    TOOLTIP_OFFSET_UNSELECTED,
+    ROUTE_POLYLINE_WEIGHT,
+    ROUTE_POLYLINE_OPACITY,
+} from '../../lib/constants'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -55,11 +63,11 @@ export function RouteBuilderFullscreenMap({
     return (
         <MapContainer
             center={UCSD_CENTER}
-            zoom={14}
+            zoom={MAP_INITIAL_ZOOM}
             scrollWheelZoom={false}
             // @ts-expect-error - smoothWheelZoom is an extended option from the plugin
             smoothWheelZoom={true}
-            smoothSensitivity={1.5}
+            smoothSensitivity={MAP_SMOOTH_WHEEL_ZOOM}
             style={{ height: '100%', width: '100%' }}
         >
             {theme === 'dark' ? (
@@ -99,7 +107,7 @@ export function RouteBuilderFullscreenMap({
                         }}
                     >
                         {showLocationLabels && (
-                            <Tooltip permanent direction="top" offset={[0, isSelected ? -10 : -36]}>
+                            <Tooltip permanent direction="top" offset={[0, isSelected ? TOOLTIP_OFFSET_SELECTED : TOOLTIP_OFFSET_UNSELECTED]}>
                                 <span className="font-medium">{loc.value}</span>
                             </Tooltip>
                         )}
@@ -108,7 +116,7 @@ export function RouteBuilderFullscreenMap({
             })}
 
             {routeGeometry && (
-                <Polyline positions={routeGeometry} color="#10b981" weight={4} opacity={0.8} />
+                <Polyline positions={routeGeometry} color="#10b981" weight={ROUTE_POLYLINE_WEIGHT} opacity={ROUTE_POLYLINE_OPACITY} />
             )}
         </MapContainer>
     )

--- a/frontend/src/components/RouteBuilder/RouteBuilderWidget.tsx
+++ b/frontend/src/components/RouteBuilder/RouteBuilderWidget.tsx
@@ -25,6 +25,7 @@ import { createNumberedIcon, defaultMarkerIcon } from './numberedMarker'
 import type { TimeModeKey } from './routeBuilderConstants'
 import type { PickupLocationsResponse } from '../../types'
 import { useUsernames } from '../../hooks/useUsernames'
+import { TOOLTIP_OFFSET_SELECTED, TOOLTIP_OFFSET_UNSELECTED, ROUTE_POLYLINE_WEIGHT, ROUTE_POLYLINE_OPACITY } from '../../lib/constants'
 
 export interface RouteBuilderWidgetProps {
     theme: string
@@ -303,7 +304,7 @@ export function RouteBuilderWidget({
                                         },
                                     }}
                                 >
-                                    <Tooltip direction="top" offset={[0, isSelected ? -10 : -36]}>
+                                    <Tooltip direction="top" offset={[0, isSelected ? TOOLTIP_OFFSET_SELECTED : TOOLTIP_OFFSET_UNSELECTED]}>
                                         <span className="font-medium">
                                             {isSelected ? `${orderIndex + 1}. ` : ''}
                                             {loc.value}
@@ -314,7 +315,7 @@ export function RouteBuilderWidget({
                         })}
 
                         {routeGeometry && (
-                            <Polyline positions={routeGeometry} color="#10b981" weight={4} opacity={0.8} />
+                            <Polyline positions={routeGeometry} color="#10b981" weight={ROUTE_POLYLINE_WEIGHT} opacity={ROUTE_POLYLINE_OPACITY} />
                         )}
                     </MapContainer>
                 </div>

--- a/frontend/src/components/RouteBuilder/routeBuilderFormat.ts
+++ b/frontend/src/components/RouteBuilder/routeBuilderFormat.ts
@@ -5,13 +5,15 @@
  * sortable list rows render identical chips/labels.
  */
 
+import { SECONDS_PER_MINUTE, MINUTES_PER_HOUR } from '../../lib/constants'
+
 /** Format an OSRM duration (seconds) as a short, human-readable label. */
 export function formatDuration(seconds: number | null | undefined): string | null {
     if (seconds == null || !isFinite(seconds) || seconds < 0) return null
-    const totalMinutes = Math.max(1, Math.round(seconds / 60))
-    if (totalMinutes < 60) return `${totalMinutes} min`
-    const hours = Math.floor(totalMinutes / 60)
-    const minutes = totalMinutes % 60
+    const totalMinutes = Math.max(1, Math.round(seconds / SECONDS_PER_MINUTE))
+    if (totalMinutes < MINUTES_PER_HOUR) return `${totalMinutes} min`
+    const hours = Math.floor(totalMinutes / MINUTES_PER_HOUR)
+    const minutes = totalMinutes % MINUTES_PER_HOUR
     return minutes === 0 ? `${hours} hr` : `${hours} hr ${minutes} min`
 }
 

--- a/frontend/src/hooks/useUsernames.ts
+++ b/frontend/src/hooks/useUsernames.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '../lib/api'
+import { QUERY_STALE_5_MIN } from '../lib/constants'
 
 export interface UsernameEntry {
     username: string
@@ -14,6 +15,6 @@ export function useUsernames() {
             const data = await res.json()
             return data.users as UsernameEntry[]
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: QUERY_STALE_5_MIN,
     })
 }

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,53 @@
+// Timing
+export const QUERY_STALE_5_MIN = 5 * 60 * 1000;
+export const QUERY_STALE_1_MIN = 60_000;
+export const COPY_FEEDBACK_MS = 2000;
+export const HINT_MESSAGE_MS = 1500;
+export const LOCATION_TOGGLE_DELAY_MS = 400;
+export const ROUTE_GENERATION_DEBOUNCE_MS = 300;
+export const INPUT_FOCUS_DELAY_MS = 30;
+
+// Pagination
+export const UPCOMING_DATES_PAGE_SIZE = 4;
+
+// Map / route builder
+export const MAP_INITIAL_ZOOM = 14;
+export const MAP_SMOOTH_WHEEL_ZOOM = 1.5;
+export const MAP_FIT_BOUNDS_PADDING = 50;
+export const MAP_FIT_BOUNDS_DURATION = 0.8;
+export const MAP_PADDING_FRACTION = 0.1;
+export const MAP_PADDING_MIN_DEGREES = 0.01;
+export const ROUTE_POLYLINE_WEIGHT = 4;
+export const ROUTE_POLYLINE_OPACITY = 0.8;
+export const TOOLTIP_OFFSET_SELECTED = -10;
+export const TOOLTIP_OFFSET_UNSELECTED = -36;
+
+// Layout
+export const MENTION_DROPDOWN_MAX_HEIGHT = 152;
+export const MENTION_DROPDOWN_LINE_HEIGHT_FALLBACK = 20;
+export const MENTION_DROPDOWN_OFFSET = 4;
+
+// Coverage
+export const COVERAGE_PERCENTAGE_MULTIPLIER = 100;
+
+// Day-of-week thresholds (getDay() values)
+export const DAY_SUNDAY = 0;
+export const DAY_FRIDAY = 5;
+export const DAY_SATURDAY = 6;
+
+// Hour thresholds for automatic day logic
+export const SUNDAY_WIDGET_START_HOUR = 16;   // Saturday 4 PM
+export const SUNDAY_WIDGET_END_HOUR = 13;     // Sunday 1 PM
+export const FRIDAY_WARNING_HOUR = 12;        // Friday noon
+export const SUNDAY_WARNING_HOUR = 17;        // Sunday 5 PM
+
+// Time conversion
+export const SECONDS_PER_MINUTE = 60;
+export const MINUTES_PER_HOUR = 60;
+
+// Local storage / URL param keys
+export const ROUTE_BUILDER_STORAGE_KEY = 'routeBuilder.state.v1';
+export const RB_PARAM_STOPS = 'rb_stops';
+export const RB_PARAM_TIME_MODE = 'rb_time_mode';
+export const RB_PARAM_LEAVE_TIME = 'rb_leave_time';
+export const RB_PARAM_DRIVER = 'rb_driver';

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,15 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 import { toast } from "sonner"
+import {
+  DAY_SUNDAY,
+  DAY_FRIDAY,
+  DAY_SATURDAY,
+  SUNDAY_WIDGET_START_HOUR,
+  SUNDAY_WIDGET_END_HOUR,
+  FRIDAY_WARNING_HOUR,
+  SUNDAY_WARNING_HOUR,
+} from './constants'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -31,7 +40,7 @@ export function getAutomaticDay(): 'friday' | 'sunday' {
   const hour = now.getHours()
 
   // Sunday widget: Saturday 4PM or later, or Sunday before 1PM
-  if ((day === 6 && hour >= 16) || (day === 0 && hour < 13)) {
+  if ((day === DAY_SATURDAY && hour >= SUNDAY_WIDGET_START_HOUR) || (day === DAY_SUNDAY && hour < SUNDAY_WIDGET_END_HOUR)) {
     return 'sunday'
   }
   return 'friday'
@@ -40,11 +49,11 @@ export function getAutomaticDay(): 'friday' | 'sunday' {
 // Friday after noon — show warning that Friday rides need drivers
 export function isFridayWarningWindow(): boolean {
   const now = new Date()
-  return now.getDay() === 5 && now.getHours() >= 12
+  return now.getDay() === DAY_FRIDAY && now.getHours() >= FRIDAY_WARNING_HOUR
 }
 
 // Saturday after 5 PM — show warning that Sunday rides need drivers
 export function isSundayWarningWindow(): boolean {
   const now = new Date()
-  return now.getDay() === 6 && now.getHours() >= 17
+  return now.getDay() === DAY_SATURDAY && now.getHours() >= SUNDAY_WARNING_HOUR
 }

--- a/frontend/src/pages/ReactionLog.tsx
+++ b/frontend/src/pages/ReactionLog.tsx
@@ -12,6 +12,7 @@ import {
 } from '../components/ui/select'
 import { BackLink, PageHeader, PageLayout } from '../components/shared'
 import { ModeToggle } from '../components/mode-toggle'
+import { QUERY_STALE_1_MIN } from '../lib/constants'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -233,7 +234,7 @@ function ReactionLog() {
             const res = await apiFetch('/api/reaction-log')
             return res.json() as Promise<ReactionLogResponse>
         },
-        staleTime: 60_000,
+        staleTime: QUERY_STALE_1_MIN,
     })
 
     const availableEmojis = Array.from(


### PR DESCRIPTION
Moves hardcoded numeric literals, strings, and durations into named constants across the full stack to improve readability and centralize configuration.

Backend API (api/constants.py): server host/port, CORS origins, Cloudflare auth TTLs, rate limits, session/cookie names, Discord OAuth URLs, access log rotation, SSE heartbeat, ask-rides and group-rides defaults.

Backend bot (bot/utils/constants.py): session TTL, LLM model and retry config, ride grouping adjustment, coverage default hours, cache TTLs, time helper thresholds, Redis timeout, default capacity string.

Frontend (lib/constants.ts): query cache stale times, UI timing delays, map/route builder config, tooltip offsets, layout dimensions, day-of-week thresholds, hour thresholds for automatic day logic, time conversion factors, local-storage and URL param keys.


