### PR TITLE
feat(list-pickups): show drive-back indicator after rider name

### DIFF
--- a/backend/api/routes/list_pickups.py
+++ b/backend/api/routes/list_pickups.py
@@ -127,6 +127,16 @@ async def list_pickups(request: ListPickupsRequest):
             locations, usernames_reacted, location_found
         )
 
+        # Fetch users who reacted with ⬅️ (drive back)
+        drive_back_usernames: set[str] = set()
+        if bot is not None and message_id_int is not None:
+            try:
+                drive_back_usernames = await locations_service.get_drive_back_usernames(
+                    channel_id_int, message_id_int
+                )
+            except Exception:
+                logger.exception("Failed to fetch drive-back reactions; proceeding without them")
+
         # Format response data for frontend
         housing_groups = {}
 
@@ -140,6 +150,7 @@ async def list_pickups(request: ListPickupsRequest):
                         {
                             "name": person[0],
                             "discord_username": str(person[1]) if person[1] else None,
+                            "drive_back": person[1] in drive_back_usernames if person[1] else False,
                         }
                         for person in people
                     ]

--- a/backend/bot/services/locations_service.py
+++ b/backend/bot/services/locations_service.py
@@ -274,6 +274,10 @@ class LocationsService:
         """Delegates to ReactionService.get_usernames_who_reacted."""
         return await self._reactions.get_usernames_who_reacted(channel_id, message_id, option)
 
+    async def get_drive_back_usernames(self, channel_id: int, message_id: int) -> set[str]:
+        """Delegates to ReactionService.get_drive_back_usernames."""
+        return await self._reactions.get_drive_back_usernames(channel_id, message_id)
+
     @property
     def get_ask_rides_reactions(self):
         """Exposes the cached ReactionService.get_ask_rides_reactions."""

--- a/backend/bot/services/reaction_service.py
+++ b/backend/bot/services/reaction_service.py
@@ -173,6 +173,27 @@ class ReactionService:
             "username_to_name": username_to_name,
         }
 
+    async def get_drive_back_usernames(self, channel_id: int, message_id: int) -> set[str]:
+        """
+        Returns the set of usernames who reacted with the drive-back (⬅️) emoji.
+
+        Args:
+            channel_id: The channel ID.
+            message_id: The message ID.
+
+        Returns:
+            A set of usernames who reacted with ⬅️.
+        """
+        channel = self.bot.get_channel(channel_id)
+        message = await channel.fetch_message(message_id)
+        usernames: set[str] = set()
+        for reaction in message.reactions:
+            if str(reaction.emoji) == Emoji.DRIVE_BACK:
+                async for user in reaction.users():
+                    if not user.bot:
+                        usernames.add(user.name)
+        return usernames
+
     @alru_cache(ttl=864000, ignore_self=True, namespace=CacheNamespace.ASK_RIDES_MESSAGE_ID)
     async def find_correct_message(self, ask_rides_message: AskRidesMessage, channel_id):
         """

--- a/frontend/src/components/PickupGroup.tsx
+++ b/frontend/src/components/PickupGroup.tsx
@@ -67,6 +67,7 @@ function PickupGroup({ groupName, groupData, onCopy }: PickupGroupProps) {
                                         ) : (
                                             <span>{person.name}</span>
                                         )}
+                                        {person.drive_back && <span className="ml-1">⬅️</span>}
                                         {idx < people.length - 1 ? ', ' : ''}
                                     </span>
                                 ))}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,7 @@ export interface HousingGroup {
         [location: string]: Array<{
             name: string
             discord_username: string | null
+            drive_back: boolean
         }>
     }
 }


### PR DESCRIPTION
If a rider reacts with ⬅️ on the ask-rides message, a ⬅️ emoji is rendered after their name in the List Pickups widget.

