### PR TITLE
feat: non-Discord rides management

### DIFF
--- a/backend/alembic/versions/c7d8e9f0a1b2_add_emoji_to_non_discord_rides.py
+++ b/backend/alembic/versions/c7d8e9f0a1b2_add_emoji_to_non_discord_rides.py
@@ -1,0 +1,30 @@
+"""
+Add emoji column to non_discord_rides.
+
+Revision ID: c7d8e9f0a1b2
+Revises: b2c3d4e5f6a1
+Create Date: 2026-06-06
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d8e9f0a1b2"
+down_revision: str | None = "b2c3d4e5f6a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add nullable emoji column to non_discord_rides."""
+    op.add_column("non_discord_rides", sa.Column("emoji", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop emoji column from non_discord_rides."""
+    op.drop_column("non_discord_rides", "emoji")

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -39,6 +39,7 @@ from api.routes.health import router as health_router
 from api.routes.list_pickups import router as list_pickups_router
 from api.routes.locations import router as locations_router
 from api.routes.me import router as me_router
+from api.routes.non_discord_rides import router as non_discord_rides_router
 from api.routes.reaction_log import router as reaction_log_router
 from api.routes.reaction_log_stream import router as reaction_log_stream_router
 from api.routes.ride_coordinators import router as ride_coordinators_router
@@ -153,6 +154,7 @@ if APP_ENV == "local":
 app.include_router(locations_router)
 app.include_router(feature_flags_router)
 app.include_router(me_router)
+app.include_router(non_discord_rides_router)
 app.include_router(ask_rides_router)
 app.include_router(cache_stats_router)
 app.include_router(group_rides_router)

--- a/backend/api/routes/ask_rides.py
+++ b/backend/api/routes/ask_rides.py
@@ -13,6 +13,7 @@ from bot.core.enums import AskRidesMessage, CacheNamespace, DaysOfWeek, JobName
 from bot.jobs.ask_rides import get_ask_rides_status, run_ask_rides_all
 from bot.services.locations_service import LocationsService
 from bot.services.message_schedule_service import MessageScheduleService
+from bot.services.non_discord_rides_service import NonDiscordRidesService
 from bot.utils.cache import invalidate_namespace
 from bot.utils.time_helpers import get_next_date_obj, get_send_wednesday
 
@@ -229,7 +230,23 @@ async def get_ask_rides_reactions(message_type: str):
             detail=f"message_type must be one of: {', '.join(valid_types)}",
         )
 
+    # Non-Discord riders are tracked per ride day; map the message type to a day.
+    type_to_day: dict[str, str] = {
+        JobName.FRIDAY: DaysOfWeek.FRIDAY,
+        JobName.SUNDAY: DaysOfWeek.SUNDAY,
+        JobName.SUNDAY_CLASS: DaysOfWeek.SUNDAY,
+    }
+
     try:
+        # Collect non-Discord riders for the day, grouped by their emoji tag.
+        non_discord: dict[str, list[str]] = {}
+        day = type_to_day.get(message_type.lower())
+        if day is not None:
+            rides = await NonDiscordRidesService().list_pickups(day)
+            for ride in rides:
+                if ride.emoji:
+                    non_discord.setdefault(ride.emoji, []).append(ride.name)
+
         locations_svc = LocationsService(bot)
         result = await locations_svc.get_ask_rides_reactions(event)
 
@@ -238,12 +255,14 @@ async def get_ask_rides_reactions(message_type: str):
                 "message_type": message_type,
                 "reactions": {},
                 "username_to_name": {},
+                "non_discord": non_discord,
                 "message_found": False,
             }
 
         return {
             "message_type": message_type,
             **result,
+            "non_discord": non_discord,
             "message_found": True,
         }
 

--- a/backend/api/routes/list_pickups.py
+++ b/backend/api/routes/list_pickups.py
@@ -99,12 +99,14 @@ async def list_pickups(request: ListPickupsRequest):
                             "It may not exist yet."
                         ),
                     )
+                # Pass day so non-Discord pickups are merged into the results.
                 (
                     locations,
                     usernames_reacted,
                     location_found,
                 ) = await locations_service.list_locations(
-                    message_id=message_id_int, channel_id=channel_id_int
+                    day=request.ride_type,
+                    channel_id=channel_id_int,
                 )
             else:
                 # Bot unavailable: serve from cache by passing day directly, which avoids

--- a/backend/api/routes/non_discord_rides.py
+++ b/backend/api/routes/non_discord_rides.py
@@ -1,0 +1,148 @@
+"""
+Non-Discord rides management API endpoints.
+
+Lets ride coordinators add/list/remove pickups for people who are not in Discord
+(and therefore never react to the ride posts). Mirrors the ``/add-pickup``,
+``/remove-pickup``, and ``/list-added-pickups`` slash commands.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from api.auth import require_ride_coordinator
+from bot.services.non_discord_rides_service import DuplicateRideError, NonDiscordRidesService
+from bot.utils.constants import LSCC_DAYS, RIDE_REACTION_LABELS
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/non-discord-rides", tags=["non-discord-rides"])
+
+service = NonDiscordRidesService()
+
+_VALID_DAYS = {day.value for day in LSCC_DAYS}
+_VALID_EMOJIS = set(RIDE_REACTION_LABELS)
+
+
+def _validate_day(day: str) -> str:
+    """Validate that the day is an allowed LSCC ride day, returning the canonical value."""
+    if day not in _VALID_DAYS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid day '{day}'. Allowed values: {', '.join(sorted(_VALID_DAYS))}.",
+        )
+    return day
+
+
+def _validate_emoji(emoji: str | None) -> str | None:
+    """Validate that the emoji (if provided) is an allowed ride-reaction emoji."""
+    if emoji is not None and emoji not in _VALID_EMOJIS:
+        raise HTTPException(status_code=400, detail=f"Invalid reaction emoji '{emoji}'.")
+    return emoji
+
+
+class NonDiscordRideResponse(BaseModel):
+    """A single non-Discord pickup entry."""
+
+    name: str
+    day: str
+    location: str | None
+    emoji: str | None
+
+
+class AddNonDiscordRideRequest(BaseModel):
+    """Request model for adding a non-Discord pickup."""
+
+    name: str = Field(min_length=1, description="Name of the person to pick up")
+    day: str = Field(description="Ride day (e.g. 'Friday' or 'Sunday')")
+    location: str = Field(min_length=1, description="Pickup location")
+    emoji: str | None = Field(
+        default=None, description="Optional ride-reaction emoji tag (e.g. lunch/no-lunch)"
+    )
+
+
+class RemoveNonDiscordRideRequest(BaseModel):
+    """Request model for removing a non-Discord pickup."""
+
+    name: str = Field(min_length=1, description="Name of the person to remove")
+    day: str = Field(description="Ride day (e.g. 'Friday' or 'Sunday')")
+
+
+@router.get("", dependencies=[Depends(require_ride_coordinator)])
+async def list_non_discord_rides(
+    day: str = Query(description="Ride day to list pickups for (e.g. 'Friday')"),
+) -> list[NonDiscordRideResponse]:
+    """List all non-Discord pickups for a given day."""
+    _validate_day(day)
+    try:
+        rides = await service.list_pickups(day)
+    except Exception as e:
+        logger.exception("Failed to list non-Discord rides")
+        raise HTTPException(status_code=500, detail="Failed to list pickups.") from e
+
+    return [
+        NonDiscordRideResponse(name=ride.name, day=day, location=ride.location, emoji=ride.emoji)
+        for ride in rides
+    ]
+
+
+@router.post("", dependencies=[Depends(require_ride_coordinator)])
+async def add_non_discord_ride(
+    body: AddNonDiscordRideRequest, request: Request
+) -> NonDiscordRideResponse:
+    """Add a non-Discord pickup for the given day."""
+    _validate_day(body.day)
+    _validate_emoji(body.emoji)
+    name = body.name.strip()
+    location = body.location.strip()
+    if not name or not location:
+        raise HTTPException(status_code=400, detail="Name and location are required.")
+
+    try:
+        ride = await service.add_pickup(name, body.day, location, emoji=body.emoji)
+    except DuplicateRideError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.exception("Failed to add non-Discord ride")
+        raise HTTPException(status_code=500, detail="Failed to add pickup.") from e
+
+    user = getattr(request.state, "user", None) or {}
+    logger.info(
+        "Non-Discord pickup added: %s on %s by %s",
+        name,
+        body.day,
+        user.get("email", "unknown"),
+    )
+    return NonDiscordRideResponse(
+        name=ride.name, day=body.day, location=ride.location, emoji=ride.emoji
+    )
+
+
+@router.delete("", dependencies=[Depends(require_ride_coordinator)])
+async def remove_non_discord_ride(body: RemoveNonDiscordRideRequest, request: Request):
+    """Remove a non-Discord pickup for the given day."""
+    _validate_day(body.day)
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Name is required.")
+
+    try:
+        removed = await service.remove_pickup(name, body.day)
+    except Exception as e:
+        logger.exception("Failed to remove non-Discord ride")
+        raise HTTPException(status_code=500, detail="Failed to remove pickup.") from e
+
+    if not removed:
+        raise HTTPException(status_code=404, detail=f"No pickup found for {name} on {body.day}.")
+
+    user = getattr(request.state, "user", None) or {}
+    logger.info(
+        "Non-Discord pickup removed: %s on %s by %s",
+        name,
+        body.day,
+        user.get("email", "unknown"),
+    )
+    return {"ok": True}

--- a/backend/api/routes/non_discord_rides.py
+++ b/backend/api/routes/non_discord_rides.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from api.auth import require_ride_coordinator
+from bot.core.enums import CampusLivingLocations
 from bot.services.non_discord_rides_service import DuplicateRideError, NonDiscordRidesService
 from bot.utils.constants import LSCC_DAYS, RIDE_REACTION_LABELS
 
@@ -40,6 +41,12 @@ def _validate_emoji(emoji: str | None) -> str | None:
     if emoji is not None and emoji not in _VALID_EMOJIS:
         raise HTTPException(status_code=400, detail=f"Invalid reaction emoji '{emoji}'.")
     return emoji
+
+
+@router.get("/campus-locations")
+async def get_campus_locations() -> list[str]:
+    """Return all valid campus living location names."""
+    return [loc.value for loc in CampusLivingLocations]
 
 
 class NonDiscordRideResponse(BaseModel):

--- a/backend/bot/core/models.py
+++ b/backend/bot/core/models.py
@@ -66,6 +66,7 @@ class NonDiscordRides(Base):
     name: Mapped[str] = mapped_column(primary_key=True)
     date: Mapped[date] = mapped_column(primary_key=True)  # ty: ignore[invalid-type-form]
     location: Mapped[str | None]
+    emoji: Mapped[str | None]
 
 
 class RideCoverage(Base):

--- a/backend/bot/services/non_discord_rides_service.py
+++ b/backend/bot/services/non_discord_rides_service.py
@@ -25,7 +25,12 @@ class NonDiscordRidesService:
     """Service for handling non-Discord ride logic."""
 
     async def add_pickup(
-        self, name: str, day: str, location: str, session: AsyncSession | None = None
+        self,
+        name: str,
+        day: str,
+        location: str,
+        emoji: str | None = None,
+        session: AsyncSession | None = None,
     ) -> NonDiscordRides:
         """
         Adds a pickup for a non-Discord user.
@@ -34,6 +39,7 @@ class NonDiscordRidesService:
             name: Name of the person.
             day: Day of the pickup (e.g., "Friday", "Sunday").
             location: Pickup location.
+            emoji: Optional ride-reaction emoji tag (e.g. lunch/no-lunch).
             session: Optional database session. If None, one is created internally.
 
         Returns:
@@ -44,16 +50,21 @@ class NonDiscordRidesService:
         """
         ride_date = get_next_date_obj(DaysOfWeek(day))
         if session is not None:
-            return await self._add_pickup(session, name, ride_date, location)
+            return await self._add_pickup(session, name, ride_date, location, emoji)
 
         async with AsyncSessionLocal() as session:
-            return await self._add_pickup(session, name, ride_date, location)
+            return await self._add_pickup(session, name, ride_date, location, emoji)
 
     async def _add_pickup(
-        self, session: AsyncSession, name: str, ride_date: date, location: str
+        self,
+        session: AsyncSession,
+        name: str,
+        ride_date: date,
+        location: str,
+        emoji: str | None = None,
     ) -> NonDiscordRides:
         try:
-            ride = NonDiscordRides(name=name, date=ride_date, location=location)
+            ride = NonDiscordRides(name=name, date=ride_date, location=location, emoji=emoji)
             return await NonDiscordRidesRepository.create_ride(session, ride)
         except IntegrityError:
             raise DuplicateRideError(f"Pickup for {name} on {ride_date} already exists.")  # noqa: B904

--- a/backend/bot/utils/constants.py
+++ b/backend/bot/utils/constants.py
@@ -1,10 +1,20 @@
 """Contains constants"""
 
-from bot.core.enums import DaysOfWeek, PickupLocations
+from bot.core.enums import DaysOfWeek, Emoji, PickupLocations
 
 GUILD_ID = 916817752918982716
 
 LSCC_DAYS = [DaysOfWeek.FRIDAY, DaysOfWeek.SUNDAY]
+
+# Ride-reaction emojis that can be tagged on a non-Discord pickup, mapped to a
+# human-readable label. Keys double as the allowlist of valid emoji tags.
+RIDE_REACTION_LABELS: dict[str, str] = {
+    Emoji.LUNCH: "Lunch",
+    Emoji.NO_LUNCH: "No lunch",
+    Emoji.SOMETHING_ELSE: "Something else",
+    Emoji.FRIDAY_FELLOWSHIP: "Friday Fellowship",
+    Emoji.SUNDAY_CLASS: "Sunday class",
+}
 
 # Coordinates (lat, lng) for each pickup location.
 # Source of truth — Google Maps links are generated from these.

--- a/frontend/src/components/CopyPill.tsx
+++ b/frontend/src/components/CopyPill.tsx
@@ -3,15 +3,22 @@ import { copyToClipboard } from '../lib/utils'
 interface CopyPillProps {
     copyStr: string
     displayStr: string
+    /** 'default' renders the standard muted pill; 'muted' renders a subdued dashed-border pill for non-Discord entries */
+    variant?: 'default' | 'muted'
 }
 
-export function CopyPill({ copyStr, displayStr }: CopyPillProps) {
+export function CopyPill({ copyStr, displayStr, variant = 'default' }: CopyPillProps) {
+    const className =
+        variant === 'muted'
+            ? 'px-2 py-1 rounded text-sm cursor-pointer transition-all duration-300 border border-dashed bg-transparent text-muted-foreground hover:bg-muted/50 border-border'
+            : 'px-2 py-1 rounded text-sm cursor-pointer transition-all duration-300 border bg-muted text-foreground hover:bg-muted/80 border-transparent'
+
     return (
         <button
             type="button"
             onClick={() => copyToClipboard(copyStr)}
-            className="px-2 py-1 rounded text-sm cursor-pointer transition-all duration-300 border bg-muted text-foreground hover:bg-muted/80 border-transparent"
-            title="Click to copy username"
+            className={className}
+            title="Click to copy"
             aria-label={`Copy ${displayStr} to clipboard`}
         >
             {displayStr}

--- a/frontend/src/components/NonDiscordRides.tsx
+++ b/frontend/src/components/NonDiscordRides.tsx
@@ -1,0 +1,306 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserPlus, Sparkles, Church, Trash2, MapPin } from 'lucide-react'
+import { apiFetch, ApiError } from '../lib/api'
+import { InfoToggleButton, InfoPanel } from './InfoHelp'
+import ErrorMessage from './ErrorMessage'
+import ConfirmDialog from './ConfirmDialog'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from './ui/select'
+import { LabeledField, RefreshIconButton, SectionCard } from './shared'
+
+type Day = 'Friday' | 'Sunday'
+
+interface NonDiscordRide {
+    name: string
+    day: string
+    location: string | null
+    emoji: string | null
+}
+
+/** Sentinel for the "no reaction tag" dropdown option (Select can't use ""). */
+const NO_REACTION = '__none__'
+
+/** Selectable ride-reaction tags per day. Emojis must match the backend Emoji enum. */
+const REACTION_OPTIONS: Record<Day, { emoji: string; label: string }[]> = {
+    Sunday: [
+        { emoji: '🍔', label: 'Lunch' },
+        { emoji: '🏠', label: 'No lunch' },
+        { emoji: '✳️', label: 'Something else' },
+    ],
+    Friday: [{ emoji: '🪨', label: 'Friday Fellowship' }],
+}
+
+/**
+ * A dashboard widget for managing non-Discord rides — pickups for people who are
+ * not in Discord and therefore never react to the ride posts. Coordinators can add,
+ * list, and remove these entries per ride day.
+ */
+function NonDiscordRides() {
+    const [day, setDay] = useState<Day>('Friday')
+    const [name, setName] = useState('')
+    const [location, setLocation] = useState('')
+    const [reaction, setReaction] = useState(NO_REACTION)
+    const [showInfo, setShowInfo] = useState(false)
+    const [pendingDelete, setPendingDelete] = useState<NonDiscordRide | null>(null)
+    const queryClient = useQueryClient()
+
+    const {
+        data: rides,
+        isLoading,
+        error,
+    } = useQuery<NonDiscordRide[]>({
+        queryKey: ['nonDiscordRides', day],
+        queryFn: async () => {
+            const response = await apiFetch(
+                `/api/non-discord-rides?day=${encodeURIComponent(day)}`
+            )
+            return response.json()
+        },
+        refetchOnWindowFocus: false,
+    })
+
+    const addMutation = useMutation({
+        mutationFn: async () => {
+            const response = await apiFetch('/api/non-discord-rides', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: name.trim(),
+                    day,
+                    location: location.trim(),
+                    emoji: reaction === NO_REACTION ? null : reaction,
+                }),
+            })
+            return response.json()
+        },
+        onSuccess: () => {
+            setName('')
+            setLocation('')
+            setReaction(NO_REACTION)
+            queryClient.invalidateQueries({ queryKey: ['nonDiscordRides', day] })
+        },
+    })
+
+    const removeMutation = useMutation({
+        mutationFn: async (ride: NonDiscordRide) => {
+            await apiFetch('/api/non-discord-rides', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: ride.name, day: ride.day }),
+            })
+        },
+        onSuccess: () => {
+            setPendingDelete(null)
+            queryClient.invalidateQueries({ queryKey: ['nonDiscordRides', day] })
+        },
+    })
+
+    const handleAdd = (e: React.FormEvent) => {
+        e.preventDefault()
+        if (!name.trim() || !location.trim()) return
+        addMutation.mutate()
+    }
+
+    const handleDayChange = (next: Day) => {
+        setDay(next)
+        // Reaction options differ per day, so reset the selection.
+        setReaction(NO_REACTION)
+    }
+
+    const addError =
+        addMutation.error instanceof ApiError
+            ? addMutation.error.detail
+            : addMutation.error
+              ? 'Failed to add pickup'
+              : ''
+
+    return (
+        <SectionCard
+            icon={<UserPlus className="h-4 w-4" />}
+            title="Non-Discord Rides"
+            actions={
+                <>
+                    <RefreshIconButton
+                        onClick={() =>
+                            queryClient.invalidateQueries({ queryKey: ['nonDiscordRides', day] })
+                        }
+                    />
+                    <InfoToggleButton
+                        isOpen={showInfo}
+                        onClick={() => setShowInfo(!showInfo)}
+                        title="About Non-Discord Rides"
+                    />
+                </>
+            }
+        >
+            <InfoPanel
+                isOpen={showInfo}
+                onClose={() => setShowInfo(false)}
+                title="About Non-Discord Rides"
+            >
+                <p className="mb-2">
+                    Use this to add pickups for people who aren't in Discord and so never react
+                    to the ride posts. These entries show up alongside the regular dropoffs.
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Entries are scoped to the next occurrence of the selected day and are cleared
+                    automatically once that day passes.
+                </p>
+            </InfoPanel>
+
+            {/* Day selector */}
+            <div className="mb-6 grid grid-cols-2 gap-3">
+                <button
+                    type="button"
+                    onClick={() => handleDayChange('Friday')}
+                    className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border text-sm font-medium transition-all ${
+                        day === 'Friday'
+                            ? 'bg-info/10 border-info text-foreground ring-1 ring-info'
+                            : 'bg-card border-border text-foreground hover:bg-accent hover:text-accent-foreground'
+                    }`}
+                >
+                    <Sparkles className="h-4 w-4" />
+                    <span>Friday Fellowship</span>
+                </button>
+                <button
+                    type="button"
+                    onClick={() => handleDayChange('Sunday')}
+                    className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border text-sm font-medium transition-all ${
+                        day === 'Sunday'
+                            ? 'bg-info/10 border-info text-foreground ring-1 ring-info'
+                            : 'bg-card border-border text-foreground hover:bg-accent hover:text-accent-foreground'
+                    }`}
+                >
+                    <Church className="h-4 w-4" />
+                    <span>Sunday Service</span>
+                </button>
+            </div>
+
+            {/* Add form */}
+            <form onSubmit={handleAdd} className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    <LabeledField label="Name">
+                        <Input
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="e.g. Jane Doe"
+                        />
+                    </LabeledField>
+                    <LabeledField label="Pickup Location">
+                        <Input
+                            value={location}
+                            onChange={(e) => setLocation(e.target.value)}
+                            placeholder="e.g. Seventh"
+                        />
+                    </LabeledField>
+                    <LabeledField label="Reaction">
+                        <Select value={reaction} onValueChange={setReaction}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="None" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={NO_REACTION}>None</SelectItem>
+                                {REACTION_OPTIONS[day].map((opt) => (
+                                    <SelectItem key={opt.emoji} value={opt.emoji}>
+                                        {opt.emoji} {opt.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </LabeledField>
+                </div>
+                <div className="flex items-center gap-3">
+                    <Button
+                        type="submit"
+                        disabled={addMutation.isPending || !name.trim() || !location.trim()}
+                    >
+                        <UserPlus className="h-4 w-4" />
+                        {addMutation.isPending ? 'Adding…' : 'Add Pickup'}
+                    </Button>
+                </div>
+                {addError && <ErrorMessage message={addError} />}
+            </form>
+
+            {/* List */}
+            <div className="mt-8">
+                <h3 className="text-sm font-semibold text-foreground mb-3">
+                    Added pickups for {day}
+                </h3>
+
+                {isLoading && (
+                    <p className="text-center py-6 text-muted-foreground">Loading…</p>
+                )}
+
+                {error && !isLoading && (
+                    <ErrorMessage message="Failed to load non-Discord rides" />
+                )}
+
+                {rides && !isLoading && !error && (
+                    rides.length === 0 ? (
+                        <p className="text-sm text-muted-foreground py-4 text-center border border-dashed border-border rounded-lg">
+                            No non-Discord pickups added for {day} yet.
+                        </p>
+                    ) : (
+                        <ul className="space-y-2">
+                            {rides.map((ride) => (
+                                <li
+                                    key={`${ride.name}-${ride.day}`}
+                                    className="flex items-center justify-between gap-3 px-3 py-2 rounded-md bg-muted"
+                                >
+                                    <div className="min-w-0">
+                                        {ride.emoji && (
+                                            <span className="mr-1" aria-hidden>
+                                                {ride.emoji}
+                                            </span>
+                                        )}
+                                        <span className="font-medium text-foreground">
+                                            {ride.name}
+                                        </span>
+                                        <span className="ml-2 inline-flex items-center gap-1 text-sm text-muted-foreground">
+                                            <MapPin className="h-3.5 w-3.5" />
+                                            {ride.location || 'No location'}
+                                        </span>
+                                    </div>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-8 w-8 p-0 text-destructive-text hover:bg-destructive/10"
+                                        onClick={() => setPendingDelete(ride)}
+                                        title={`Remove ${ride.name}`}
+                                        aria-label={`Remove ${ride.name}`}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </li>
+                            ))}
+                        </ul>
+                    )
+                )}
+            </div>
+
+            <ConfirmDialog
+                isOpen={pendingDelete !== null}
+                title="Remove pickup"
+                description={
+                    pendingDelete
+                        ? `Remove the pickup for ${pendingDelete.name} on ${pendingDelete.day}?`
+                        : ''
+                }
+                confirmText={removeMutation.isPending ? 'Removing…' : 'Remove'}
+                confirmVariant="destructive"
+                onConfirm={() => pendingDelete && removeMutation.mutate(pendingDelete)}
+                onCancel={() => setPendingDelete(null)}
+            />
+        </SectionCard>
+    )
+}
+
+export default NonDiscordRides

--- a/frontend/src/components/NonDiscordRides.tsx
+++ b/frontend/src/components/NonDiscordRides.tsx
@@ -28,6 +28,9 @@ interface NonDiscordRide {
 /** Sentinel for the "no reaction tag" dropdown option (Select can't use ""). */
 const NO_REACTION = '__none__'
 
+/** Sentinel for the "Custom" location option. */
+const CUSTOM_LOCATION = '__custom__'
+
 /** Selectable ride-reaction tags per day. Emojis must match the backend Emoji enum. */
 const REACTION_OPTIONS: Record<Day, { emoji: string; label: string }[]> = {
     Sunday: [
@@ -46,11 +49,23 @@ const REACTION_OPTIONS: Record<Day, { emoji: string; label: string }[]> = {
 function NonDiscordRides() {
     const [day, setDay] = useState<Day>('Friday')
     const [name, setName] = useState('')
-    const [location, setLocation] = useState('')
+    const [locationSelect, setLocationSelect] = useState('')
+    const [customLocation, setCustomLocation] = useState('')
     const [reaction, setReaction] = useState(NO_REACTION)
+
+    const location = locationSelect === CUSTOM_LOCATION ? customLocation : locationSelect
     const [showInfo, setShowInfo] = useState(false)
     const [pendingDelete, setPendingDelete] = useState<NonDiscordRide | null>(null)
     const queryClient = useQueryClient()
+
+    const { data: campusLocations = [] } = useQuery<string[]>({
+        queryKey: ['campusLocations'],
+        queryFn: async () => {
+            const response = await apiFetch('/api/non-discord-rides/campus-locations')
+            return response.json()
+        },
+        staleTime: Infinity,
+    })
 
     const {
         data: rides,
@@ -83,7 +98,8 @@ function NonDiscordRides() {
         },
         onSuccess: () => {
             setName('')
-            setLocation('')
+            setLocationSelect('')
+            setCustomLocation('')
             setReaction(NO_REACTION)
             queryClient.invalidateQueries({ queryKey: ['nonDiscordRides', day] })
         },
@@ -195,11 +211,25 @@ function NonDiscordRides() {
                         />
                     </LabeledField>
                     <LabeledField label="Pickup Location">
-                        <Input
-                            value={location}
-                            onChange={(e) => setLocation(e.target.value)}
-                            placeholder="e.g. Seventh"
-                        />
+                        <Select value={locationSelect} onValueChange={setLocationSelect}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Select location…" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {campusLocations.map((loc) => (
+                                    <SelectItem key={loc} value={loc}>{loc}</SelectItem>
+                                ))}
+                                <SelectItem value={CUSTOM_LOCATION}>Custom…</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        {locationSelect === CUSTOM_LOCATION && (
+                            <Input
+                                className="mt-2"
+                                value={customLocation}
+                                onChange={(e) => setCustomLocation(e.target.value)}
+                                placeholder="Enter location"
+                            />
+                        )}
                     </LabeledField>
                     <LabeledField label="Reaction">
                         <Select value={reaction} onValueChange={setReaction}>

--- a/frontend/src/components/ReactionDetails.tsx
+++ b/frontend/src/components/ReactionDetails.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Sparkles, Church, BookOpen, ClipboardList } from 'lucide-react'
+import { Sparkles, Church, BookOpen, ClipboardList, ChevronDown } from 'lucide-react'
 import type React from 'react'
 import { getAutomaticDay } from '../lib/utils'
 import { apiFetch, ApiError } from '../lib/api'
@@ -26,6 +26,18 @@ const MESSAGE_TYPES: MessageTypeOption[] = [
     { value: 'sunday_class', label: 'Sunday Class', icon: <BookOpen className="h-4 w-4" /> },
 ]
 
+/** Human-readable labels for ride-reaction emojis, shown in the overview. */
+const EMOJI_LABELS: Record<string, string> = {
+    '🍔': 'Lunch',
+    '🏠': 'No lunch',
+    '✳️': 'Something else',
+    '🪨': 'Friday Fellowship',
+    '📖': 'Sunday class',
+    '➡️': 'Drive there',
+    '⬅️': 'Drive back',
+    '✅': 'Confirmed',
+}
+
 function ReactionDetails() {
     const [data, setData] = useState<AskRidesReactionsData | null>(null)
     const [loading, setLoading] = useState(false)
@@ -33,6 +45,7 @@ function ReactionDetails() {
     const [selectedType, setSelectedType] = useState<MessageType>('friday')
 
     const [showInfo, setShowInfo] = useState(false)
+    const [showDetail, setShowDetail] = useState(false)
 
 
 
@@ -80,10 +93,25 @@ function ReactionDetails() {
 
     const selectedOption = MESSAGE_TYPES.find(t => t.value === selectedType)
 
+    // Build the combined overview: Discord reactions + tagged non-Discord riders.
+    const reactions = data?.reactions ?? {}
+    const nonDiscord = data?.non_discord ?? {}
+    const overviewRows = Array.from(
+        new Set([...Object.keys(reactions), ...Object.keys(nonDiscord)])
+    )
+        .map((emoji) => {
+            const reacted = reactions[emoji]?.length ?? 0
+            const added = nonDiscord[emoji]?.length ?? 0
+            return { emoji, reacted, added, total: reacted + added }
+        })
+        .sort((a, b) => b.total - a.total)
+    const uniqueReacted = new Set(Object.values(reactions).flat()).size
+    const totalAdded = Object.values(nonDiscord).reduce((sum, names) => sum + names.length, 0)
+
     return (
         <SectionCard
             icon={<ClipboardList className="h-4 w-4" />}
-            title="Ask Rides Reactions"
+            title="Ask Rides Overview"
             actions={
                 <>
                     <RefreshIconButton
@@ -94,7 +122,7 @@ function ReactionDetails() {
                     <InfoToggleButton
                         isOpen={showInfo}
                         onClick={() => setShowInfo(!showInfo)}
-                        title="About Ask Rides Reactions"
+                        title="About Ask Rides Overview"
                     />
                 </>
             }
@@ -102,7 +130,7 @@ function ReactionDetails() {
                 <InfoPanel
                     isOpen={showInfo}
                     onClose={() => setShowInfo(false)}
-                    title="About Ask Rides Reactions"
+                    title="About Ask Rides Overview"
                 >
                     <div className="mb-3 p-3 bg-muted/50 rounded-lg border border-border">
                         <p className="text-sm font-medium text-foreground">
@@ -113,14 +141,14 @@ function ReactionDetails() {
                         </p>
                     </div>
                     <p className="mb-2">
-                        This widget shows detailed reactions from the ask rides announcements channel.
+                        A per-reaction overview for the ask rides announcement, combining Discord
+                        reactions with manually-added non-Discord riders.
                     </p>
                     <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+                        <li>Each row shows the total for a reaction, split as <strong>reacted + added</strong> when manual entries exist.</li>
+                        <li><strong>Reacted</strong> counts always match the Discord post exactly; <strong>added</strong> comes from the Non-Discord Rides widget.</li>
                         <li>Automatically defaults to <strong>Friday</strong> or <strong>Sunday</strong> based on the time.</li>
-                        <li>Select a message type using the buttons above.</li>
-                        <li>Expand the list to see who reacted with each emoji.</li>
-                        <li>Click on any username to copy it to your clipboard.</li>
-                        <li>Click the refresh button to update data.</li>
+                        <li>Expand <strong>Who reacted</strong> to see names; click a name to copy it.</li>
                     </ul>
                 </InfoPanel>
 
@@ -146,44 +174,106 @@ function ReactionDetails() {
 
                 {!loading && !error && data && (
                     <div className="bg-card rounded-lg border border-border overflow-hidden transition-all duration-300">
-                        {!data.message_found ? (
+                        {!data.message_found && overviewRows.length === 0 ? (
                             <div className="text-center py-8 text-muted-foreground italic">
                                 No message found for {selectedOption?.label} this week.
                             </div>
                         ) : (
                             <div className="p-0">
+                                {/* Overview header */}
                                 <div className="p-4 bg-muted/50 border-b border-border flex justify-between items-center">
-                                    <h3 className="font-semibold text-foreground">
-                                        Reaction Breakdown
-                                    </h3>
+                                    <h3 className="font-semibold text-foreground">Overview</h3>
                                     <span className="text-xs font-medium text-muted-foreground uppercase tracking-widest">
-                                        {new Set(Object.values(data.reactions).flat()).size} Total People
+                                        {uniqueReacted} reacted{totalAdded > 0 ? ` + ${totalAdded} added` : ''}
                                     </span>
                                 </div>
 
-                                {Object.keys(data.reactions).length === 0 ? (
-                                    <div className="text-center py-8 text-muted-foreground">No reactions found yet.</div>
+                                {!data.message_found && (
+                                    <div className="px-4 pt-3 text-xs text-muted-foreground italic">
+                                        No Discord message found yet — showing manually added riders only.
+                                    </div>
+                                )}
+
+                                {/* Category overview */}
+                                {overviewRows.length === 0 ? (
+                                    <div className="text-center py-8 text-muted-foreground">No reactions yet.</div>
                                 ) : (
-                                    <div className="p-4 space-y-6">
-                                        {Object.entries(data.reactions).map(([emoji, usernames]) => (
-                                            <div key={emoji}>
-                                                <div className="flex items-center gap-2 mb-3">
-                                                    <span className="text-2xl">{emoji}</span>
-                                                    <span className="text-sm font-bold text-muted-foreground uppercase tracking-wider">
-                                                        {usernames.length} {usernames.length === 1 ? 'Person' : 'People'}
+                                    <div className="p-4 space-y-2">
+                                        {overviewRows.map((row) => (
+                                            <div
+                                                key={row.emoji}
+                                                className="flex items-center justify-between px-3 py-2 rounded-md bg-muted"
+                                            >
+                                                <div className="flex items-center gap-2 min-w-0">
+                                                    <span className="text-xl">{row.emoji}</span>
+                                                    <span className="text-sm font-medium text-foreground">
+                                                        {EMOJI_LABELS[row.emoji] ?? row.emoji}
                                                     </span>
                                                 </div>
-                                                <div className="flex flex-wrap gap-2 pl-1">
-                                                    {usernames.map((username) => (
-                                                        <CopyPill
-                                                            key={username}
-                                                            copyStr={"@" + username}
-                                                            displayStr={data.username_to_name[username] || ("@" + username)}
-                                                        />
-                                                    ))}
+                                                <div className="text-sm text-foreground whitespace-nowrap">
+                                                    <span className="font-semibold">{row.total}</span>
+                                                    {row.added > 0 && (
+                                                        <span className="text-muted-foreground">
+                                                            {' '}({row.reacted} reacted + {row.added} added)
+                                                        </span>
+                                                    )}
                                                 </div>
                                             </div>
                                         ))}
+                                    </div>
+                                )}
+
+                                {/* Collapsible: who reacted (Discord + non-Discord) */}
+                                {(Object.keys(reactions).length > 0 || Object.keys(nonDiscord).length > 0) && (
+                                    <div className="border-t border-border">
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowDetail(v => !v)}
+                                            className="w-full px-4 py-3 flex items-center justify-between text-sm font-medium text-foreground hover:bg-muted/50 transition-colors"
+                                        >
+                                            <span>Who reacted</span>
+                                            <ChevronDown
+                                                className={`h-4 w-4 transition-transform ${showDetail ? 'rotate-180' : ''}`}
+                                            />
+                                        </button>
+                                        {showDetail && (
+                                            <div className="p-4 space-y-6">
+                                                {Array.from(
+                                                    new Set([...Object.keys(reactions), ...Object.keys(nonDiscord)])
+                                                ).map((emoji) => {
+                                                    const discordUsers = reactions[emoji] ?? []
+                                                    const nonDiscordNames = nonDiscord[emoji] ?? []
+                                                    const total = discordUsers.length + nonDiscordNames.length
+                                                    return (
+                                                        <div key={emoji}>
+                                                            <div className="flex items-center gap-2 mb-3">
+                                                                <span className="text-2xl">{emoji}</span>
+                                                                <span className="text-sm font-bold text-muted-foreground uppercase tracking-wider">
+                                                                    {total} {total === 1 ? 'Person' : 'People'}
+                                                                </span>
+                                                            </div>
+                                                            <div className="flex flex-wrap gap-2 pl-1">
+                                                                {discordUsers.map((username) => (
+                                                                    <CopyPill
+                                                                        key={username}
+                                                                        copyStr={"@" + username}
+                                                                        displayStr={data.username_to_name[username] || ("@" + username)}
+                                                                    />
+                                                                ))}
+                                                                {nonDiscordNames.map((name) => (
+                                                                    <CopyPill
+                                                                        key={`nd-${name}`}
+                                                                        copyStr={name}
+                                                                        displayStr={name}
+                                                                        variant="muted"
+                                                                    />
+                                                                ))}
+                                                            </div>
+                                                        </div>
+                                                    )
+                                                })}
+                                            </div>
+                                        )}
                                     </div>
                                 )}
                             </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,11 +1,12 @@
 import { Suspense, lazy, useMemo } from 'react'
 import ErrorBoundary from '../components/ErrorBoundary'
 import { Link } from 'react-router-dom'
-import { BookOpen, Car, History, MapPin, Users, Map, Shield, CalendarDays, ClipboardList, Target, Navigation, UserCheck } from 'lucide-react'
+import { BookOpen, Car, History, MapPin, Users, Map, Shield, CalendarDays, ClipboardList, Target, Navigation, UserCheck, UserPlus } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '../lib/api'
 import type { AccountRole } from '../types'
 import PickupLocations from '../components/PickupLocations'
+import NonDiscordRides from '../components/NonDiscordRides'
 import DriverReactions from '../components/DriverReactions'
 import ReactionDetails from '../components/ReactionDetails'
 import GroupRides from '../components/GroupRides'
@@ -40,18 +41,32 @@ const NAV_ITEMS = [
     { id: 'roles', label: 'Roles', icon: <UserCheck className="h-4 w-4" /> },
 ]
 
-const SECTION_IDS = NAV_ITEMS.map((item) => item.id)
-
-function SectionNav({ isAdmin }: { isAdmin: boolean }) {
-    const activeId = useActiveSection(SECTION_IDS)
-
+function SectionNav({ isAdmin, canManage }: { isAdmin: boolean; canManage: boolean }) {
     const items = useMemo(() => {
-        if (!isAdmin) return NAV_ITEMS
-        return [
-            ...NAV_ITEMS,
-            { id: 'admin', label: 'Admin', icon: <Shield className="h-4 w-4" /> },
-        ]
-    }, [isAdmin])
+        let result = NAV_ITEMS
+        if (canManage) {
+            const pickupsIdx = result.findIndex((item) => item.id === 'pickup-locations')
+            const nonDiscordItem = {
+                id: 'non-discord-rides',
+                label: 'Non-Discord',
+                icon: <UserPlus className="h-4 w-4" />,
+            }
+            result = [
+                ...result.slice(0, pickupsIdx + 1),
+                nonDiscordItem,
+                ...result.slice(pickupsIdx + 1),
+            ]
+        }
+        if (isAdmin) {
+            result = [
+                ...result,
+                { id: 'admin', label: 'Admin', icon: <Shield className="h-4 w-4" /> },
+            ]
+        }
+        return result
+    }, [isAdmin, canManage])
+
+    const activeId = useActiveSection(items.map((item) => item.id))
 
     return (
         <aside className="hidden xl:block w-44 shrink-0">
@@ -143,7 +158,7 @@ function Home() {
                 }
             >
                 <div className="flex gap-8">
-                    <SectionNav isAdmin={isAdmin} />
+                    <SectionNav isAdmin={isAdmin} canManage={canManage} />
 
                     <div className="flex-1 min-w-0 grid grid-cols-1 gap-8">
                         <RideCoverageWarning />
@@ -167,6 +182,12 @@ function Home() {
                         <div id="pickup-locations">
                             <PickupLocations />
                         </div>
+
+                        {canManage && (
+                            <div id="non-discord-rides">
+                                <NonDiscordRides />
+                            </div>
+                        )}
 
                         <div id="group-rides">
                             <GroupRides />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -110,6 +110,8 @@ export interface AskRidesReactionsData {
     message_type: string
     reactions: Record<string, string[]>
     username_to_name: Record<string, string>
+    /** Names of non-Discord riders tagged with each emoji, for the day */
+    non_discord?: Record<string, string[]>
     message_found: boolean
 }
 


### PR DESCRIPTION
## Summary

- New Non-Discord Rides widget to add/list/remove pickups for people not in Discord, with per-day emoji reaction tagging and a location dropdown backed by the `CampusLivingLocations` enum
- Reworked Ask Rides Reactions into a combined overview showing Discord reactions + manually-tagged non-Discord riders per emoji
- Non-Discord riders are merged into List Pickups results
- Added `emoji` column to `non_discord_rides` table (migration included)